### PR TITLE
Use internal ID for messages

### DIFF
--- a/bindings/prose-sdk-ffi/src/client.rs
+++ b/bindings/prose-sdk-ffi/src/client.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use parking_lot::{Mutex, RwLock};
 use tracing::info;
 
-use prose_core_client::dtos::{Availability, Emoji, MessageRemoteId, UserProfile};
+use prose_core_client::dtos::{Availability, Emoji, MessageId, UserProfile};
 use prose_core_client::infra::encryption::{EncryptionKeysRepository, SessionRepository};
 use prose_core_client::infra::general::OsRngProvider;
 use prose_core_client::{
@@ -139,7 +139,7 @@ impl Client {
     pub async fn load_latest_messages(
         &self,
         _from: JID,
-        _since: Option<MessageRemoteId>,
+        _since: Option<MessageId>,
         _load_from_server: bool,
     ) -> Result<Vec<Message>, ClientError> {
         todo!("Use Room API");
@@ -153,7 +153,7 @@ impl Client {
     pub async fn load_messages_with_ids(
         &self,
         _conversation: JID,
-        _ids: Vec<MessageRemoteId>,
+        _ids: Vec<MessageId>,
     ) -> Result<Vec<Message>, ClientError> {
         todo!("Use Room API");
         // let messages = self
@@ -172,7 +172,7 @@ impl Client {
     pub async fn update_message(
         &self,
         _conversation: JID,
-        _id: MessageRemoteId,
+        _id: MessageId,
         _body: String,
     ) -> Result<(), ClientError> {
         todo!("Use Room API");
@@ -185,7 +185,7 @@ impl Client {
     pub async fn toggle_reaction_to_message(
         &self,
         _conversation: JID,
-        _id: MessageRemoteId,
+        _id: MessageId,
         _emoji: Emoji,
     ) -> Result<(), ClientError> {
         todo!("Use Room API");
@@ -198,7 +198,7 @@ impl Client {
     pub async fn retract_message(
         &self,
         _conversation: JID,
-        _id: MessageRemoteId,
+        _id: MessageId,
     ) -> Result<(), ClientError> {
         todo!("Use Room API");
         // self.client

--- a/bindings/prose-sdk-ffi/src/prose_sdk_ffi.udl
+++ b/bindings/prose-sdk-ffi/src/prose_sdk_ffi.udl
@@ -7,9 +7,7 @@ typedef string PathBuf;
 [Custom]
 typedef string Url;
 [Custom]
-typedef string MessageRemoteId;
-[Custom]
-typedef string MessageServerId;
+typedef string MessageId;
 [Custom]
 typedef string Emoji;
 [Custom]
@@ -55,9 +53,9 @@ interface ClientEvent {
     ConnectionStatusChanged(ConnectionEvent event);
     ContactChanged(JID jid);
     AvatarChanged(JID jid);
-    MessagesAppended(JID conversation, sequence<MessageRemoteId> message_ids);
-    MessagesUpdated(JID conversation, sequence<MessageRemoteId> message_ids);
-    MessagesDeleted(JID conversation, sequence<MessageRemoteId> message_ids);
+    MessagesAppended(JID conversation, sequence<MessageId> message_ids);
+    MessagesUpdated(JID conversation, sequence<MessageId> message_ids);
+    MessagesDeleted(JID conversation, sequence<MessageId> message_ids);
 };
 
 [Enum]

--- a/bindings/prose-sdk-ffi/src/types/client_event.rs
+++ b/bindings/prose-sdk-ffi/src/types/client_event.rs
@@ -4,7 +4,7 @@
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
 use crate::uniffi_types::JID;
-use prose_core_client::dtos::MessageRemoteId;
+use prose_core_client::dtos::MessageId;
 use prose_core_client::ConnectionEvent;
 
 pub enum ClientEvent {
@@ -23,19 +23,19 @@ pub enum ClientEvent {
     /// One or many messages were either received or sent.
     MessagesAppended {
         conversation: JID,
-        message_ids: Vec<MessageRemoteId>,
+        message_ids: Vec<MessageId>,
     },
 
     /// One or many messages were received that affected earlier messages (e.g. a reaction).
     MessagesUpdated {
         conversation: JID,
-        message_ids: Vec<MessageRemoteId>,
+        message_ids: Vec<MessageId>,
     },
 
     /// A message was deleted.
     MessagesDeleted {
         conversation: JID,
-        message_ids: Vec<MessageRemoteId>,
+        message_ids: Vec<MessageId>,
     },
 }
 

--- a/bindings/prose-sdk-ffi/src/types/message.rs
+++ b/bindings/prose-sdk-ffi/src/types/message.rs
@@ -5,7 +5,7 @@
 
 use chrono::{DateTime as ChronoDateTime, Utc};
 
-use prose_core_client::dtos::{Emoji, Message as ProseMessage, MessageRemoteId, MessageServerId};
+use prose_core_client::dtos::{Emoji, Message as ProseMessage, MessageId};
 
 use crate::types::JID;
 
@@ -19,8 +19,7 @@ pub struct Reaction {
 
 #[derive(uniffi::Record)]
 pub struct Message {
-    pub id: Option<MessageRemoteId>,
-    pub stanza_id: Option<MessageServerId>,
+    pub id: MessageId,
     pub from: Option<JID>,
     pub body: String,
     pub timestamp: DateTime,
@@ -34,7 +33,6 @@ impl From<ProseMessage> for Message {
     fn from(value: ProseMessage) -> Self {
         Message {
             id: value.id,
-            stanza_id: value.stanza_id,
             from: value.from.id.to_user_id().map(|id| id.into_inner().into()),
             body: todo!(),
             timestamp: value.timestamp,

--- a/bindings/prose-sdk-ffi/src/uniffi_api.rs
+++ b/bindings/prose-sdk-ffi/src/uniffi_api.rs
@@ -10,7 +10,8 @@ pub use std::path::PathBuf;
 pub use jid::{BareJid, Error as JidParseError, FullJid};
 
 pub use prose_core_client::dtos::{
-    Address, Availability, Emoji, MessageRemoteId, MessageServerId, Url, UserProfile, UserStatus,
+    Address, Availability, Emoji, MessageId, MessageRemoteId, MessageServerId, Url, UserProfile,
+    UserStatus,
 };
 pub use prose_core_client::ConnectionEvent;
 pub use prose_xmpp::ConnectionError;
@@ -20,19 +21,7 @@ pub use crate::{
     account_bookmarks_client::AccountBookmarksClient, client::*, logger::*, ClientError,
 };
 
-impl UniffiCustomTypeConverter for MessageRemoteId {
-    type Builtin = String;
-
-    fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
-        Ok(val.into())
-    }
-
-    fn from_custom(obj: Self) -> Self::Builtin {
-        obj.into_inner()
-    }
-}
-
-impl UniffiCustomTypeConverter for MessageServerId {
+impl UniffiCustomTypeConverter for MessageId {
     type Builtin = String;
 
     fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
@@ -102,7 +91,7 @@ pub mod uniffi_types {
         client::Client,
         types::{parse_jid, AccountBookmark, DateTime, Message, Reaction, JID},
         Availability, ClientError, ConnectionError, Contact, Emoji, FullJid, JidParseError,
-        MessageRemoteId, MessageServerId, PathBuf, Url, UserProfile,
+        MessageId, PathBuf, Url, UserProfile,
     };
 }
 

--- a/bindings/prose-sdk-js/src/delegate.rs
+++ b/bindings/prose-sdk-js/src/delegate.rs
@@ -6,7 +6,7 @@
 use tracing::warn;
 use wasm_bindgen::prelude::*;
 
-use prose_core_client::dtos::MessageRemoteId;
+use prose_core_client::dtos::{MessageId, MessageRemoteId};
 use prose_core_client::{ClientDelegate, ClientEvent, ClientRoomEventType, ConnectionEvent};
 use prose_xmpp::ConnectionError;
 
@@ -216,6 +216,14 @@ trait JSValueConvertible {
 }
 
 impl JSValueConvertible for Vec<MessageRemoteId> {
+    fn into_js_array(self) -> Vec<JsValue> {
+        self.into_iter()
+            .map(|id| JsValue::from(id.into_inner()))
+            .collect()
+    }
+}
+
+impl JSValueConvertible for Vec<MessageId> {
     fn into_js_array(self) -> Vec<JsValue> {
         self.into_iter()
             .map(|id| JsValue::from(id.into_inner()))

--- a/bindings/prose-sdk-js/src/types/message.rs
+++ b/bindings/prose-sdk-js/src/types/message.rs
@@ -41,8 +41,7 @@ pub struct Body {
 
 #[wasm_bindgen]
 pub struct Message {
-    id: Option<String>,
-    stanza_id: Option<ArchiveID>,
+    id: String,
     from: MessageSender,
     body: Body,
     timestamp: js_sys::Date,
@@ -96,8 +95,7 @@ impl From<dtos::Message> for Message {
             .collect_into_js_array();
 
         Self {
-            id: value.id.map(|id| id.to_string()),
-            stanza_id: value.stanza_id.map(ArchiveID::from),
+            id: value.id.to_string(),
             from: value.from.into(),
             body: Body {
                 raw: value.body.raw,
@@ -128,18 +126,13 @@ impl From<dtos::Message> for Message {
 #[wasm_bindgen]
 impl Message {
     #[wasm_bindgen(getter)]
-    pub fn id(&self) -> Option<String> {
-        self.id.as_ref().map(|id| id.to_string())
+    pub fn id(&self) -> String {
+        self.id.to_string()
     }
 
     #[wasm_bindgen(setter)]
-    pub fn set_id(&mut self, id: Option<String>) {
-        self.id = id.clone().map(Into::into)
-    }
-
-    #[wasm_bindgen(getter, js_name = "archiveId")]
-    pub fn stanza_id(&self) -> Option<ArchiveID> {
-        self.stanza_id.clone()
+    pub fn set_id(&mut self, id: String) {
+        self.id = id.into()
     }
 
     #[wasm_bindgen(getter, js_name = "from")]

--- a/bindings/prose-sdk-js/src/types/room.rs
+++ b/bindings/prose-sdk-js/src/types/room.rs
@@ -8,7 +8,7 @@ use tracing::debug;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{JsError, JsValue};
 
-use prose_core_client::dtos::{MessageRemoteId, RoomEnvelope, RoomState as SdkRoomState};
+use prose_core_client::dtos::{MessageId, RoomEnvelope, RoomState as SdkRoomState};
 use prose_core_client::services::{
     DirectMessage, Generic, Group, PrivateChannel, PublicChannel, Room as SdkRoom,
 };
@@ -337,9 +337,9 @@ macro_rules! base_room_impl {
                 &self,
                 message_ids: &StringArray,
             ) -> Result<MessagesArray> {
-                let message_ids: Vec<MessageRemoteId> = Vec::<String>::try_from(message_ids)?
+                let message_ids: Vec<MessageId> = Vec::<String>::try_from(message_ids)?
                     .into_iter()
-                    .map(|id| MessageRemoteId::from(id))
+                    .map(|id| MessageId::from(id))
                     .collect();
 
                 let messages = self

--- a/crates/prose-core-client/src/app/deps/app_dependencies.rs
+++ b/crates/prose-core-client/src/app/deps/app_dependencies.rs
@@ -27,7 +27,7 @@ use crate::domain::general::services::RequestHandlingService;
 use crate::domain::messaging::repos::{
     DraftsRepository, MessagesRepository, OfflineMessagesRepository,
 };
-use crate::domain::messaging::services::MessageArchiveDomainService;
+use crate::domain::messaging::services::{MessageArchiveDomainService, MessageIdProvider};
 use crate::domain::messaging::services::{
     MessageArchiveService, MessageMigrationDomainService, MessagingService,
 };
@@ -68,6 +68,7 @@ pub type DynIDProvider = Arc<dyn IDProvider>;
 pub type DynLocalRoomSettingsRepository = Arc<dyn LocalRoomSettingsRepository>;
 pub type DynMessageArchiveDomainService = Arc<dyn MessageArchiveDomainService>;
 pub type DynMessageArchiveService = Arc<dyn MessageArchiveService>;
+pub type DynMessageIdProvider = Arc<dyn MessageIdProvider>;
 pub type DynMessageMigrationDomainService = Arc<dyn MessageMigrationDomainService>;
 pub type DynMessagesRepository = Arc<dyn MessagesRepository>;
 pub type DynMessagingService = Arc<dyn MessagingService>;
@@ -107,6 +108,7 @@ pub struct AppDependencies {
     pub drafts_repo: DynDraftsRepository,
     pub encryption_domain_service: DynEncryptionDomainService,
     pub id_provider: DynIDProvider,
+    pub message_id_provider: DynMessageIdProvider,
     pub local_room_settings_repo: DynLocalRoomSettingsRepository,
     pub message_archive_service: DynMessageArchiveService,
     pub messages_repo: DynMessagesRepository,

--- a/crates/prose-core-client/src/app/dtos/message.rs
+++ b/crates/prose-core-client/src/app/dtos/message.rs
@@ -5,13 +5,13 @@
 
 use chrono::{DateTime, Utc};
 
+use crate::domain::messaging::models::MessageId;
 use crate::domain::shared::models::ParticipantId;
-use crate::dtos::{Attachment, Avatar, Body, Emoji, Mention, MessageRemoteId, MessageServerId};
+use crate::dtos::{Attachment, Avatar, Body, Emoji, Mention};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Message {
-    pub id: Option<MessageRemoteId>,
-    pub stanza_id: Option<MessageServerId>,
+    pub id: MessageId,
     pub from: MessageSender,
     pub body: Body,
     pub timestamp: DateTime<Utc>,

--- a/crates/prose-core-client/src/app/dtos/mod.rs
+++ b/crates/prose-core-client/src/app/dtos/mod.rs
@@ -28,7 +28,7 @@ pub use crate::domain::{
     general::models::SoftwareVersion,
     messaging::models::{
         Attachment, AttachmentType, Body, Emoji, EncryptedPayload, EncryptionKey, Mention,
-        MessageRemoteId, MessageServerId, Thumbnail,
+        MessageId, MessageRemoteId, MessageServerId, Thumbnail,
     },
     rooms::models::{Participant, PublicRoomInfo, RoomAffiliation, RoomState},
     shared::models::{

--- a/crates/prose-core-client/src/client_event.rs
+++ b/crates/prose-core-client/src/client_event.rs
@@ -8,7 +8,7 @@ use std::fmt::{Debug, Formatter};
 use prose_xmpp::ConnectionError;
 
 use crate::app::dtos::RoomEnvelope;
-use crate::domain::messaging::models::MessageRemoteId;
+use crate::domain::messaging::models::MessageId;
 use crate::domain::shared::models::UserId;
 
 #[derive(Clone, PartialEq)]
@@ -46,13 +46,13 @@ pub enum ClientEvent {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ClientRoomEventType {
     /// One or many messages were either received or sent.
-    MessagesAppended { message_ids: Vec<MessageRemoteId> },
+    MessagesAppended { message_ids: Vec<MessageId> },
 
     /// One or many messages were received that affected earlier messages (e.g. a reaction).
-    MessagesUpdated { message_ids: Vec<MessageRemoteId> },
+    MessagesUpdated { message_ids: Vec<MessageId> },
 
     /// A message was deleted.
-    MessagesDeleted { message_ids: Vec<MessageRemoteId> },
+    MessagesDeleted { message_ids: Vec<MessageId> },
 
     /// The room went offline, came back online and contains new messages.
     MessagesNeedReload,

--- a/crates/prose-core-client/src/domain/encryption/services/encryption_domain_service.rs
+++ b/crates/prose-core-client/src/domain/encryption/services/encryption_domain_service.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use prose_wasm_utils::{SendUnlessWasm, SyncUnlessWasm};
 
 use crate::domain::encryption::models::{DecryptionContext, DeviceId, DeviceInfo, DeviceList};
-use crate::domain::messaging::models::{EncryptedPayload, KeyTransportPayload, MessageRemoteId};
+use crate::domain::messaging::models::{EncryptedPayload, KeyTransportPayload, MessageId};
 use crate::domain::shared::models::{RoomId, UserId};
 
 #[derive(Debug, thiserror::Error)]
@@ -51,7 +51,7 @@ pub trait EncryptionDomainService: SendUnlessWasm + SyncUnlessWasm {
         &self,
         sender_id: &UserId,
         room_id: &RoomId,
-        message_id: Option<&MessageRemoteId>,
+        message_id: Option<&MessageId>,
         payload: EncryptedPayload,
         context: Option<DecryptionContext>,
     ) -> Result<String, DecryptionError>;

--- a/crates/prose-core-client/src/domain/encryption/services/impls/encryption_domain_service.rs
+++ b/crates/prose-core-client/src/domain/encryption/services/impls/encryption_domain_service.rs
@@ -29,10 +29,10 @@ use crate::domain::encryption::models::{
 use crate::domain::encryption::services::encryption_domain_service::{
     DecryptionError, EncryptionError,
 };
-use crate::domain::messaging::models::MessageLikePayload;
 use crate::domain::messaging::models::{EncryptedPayload, KeyTransportPayload};
+use crate::domain::messaging::models::{MessageId, MessageLikePayload};
 use crate::domain::shared::models::{AccountId, UserId};
-use crate::dtos::{EncryptionKey, MessageRemoteId, PreKeyId, RoomId};
+use crate::dtos::{EncryptionKey, PreKeyId, RoomId};
 use crate::util::join_all;
 
 use super::super::EncryptionDomainService as EncryptionDomainServiceTrait;
@@ -288,7 +288,7 @@ impl EncryptionDomainServiceTrait for EncryptionDomainService {
         &self,
         sender_id: &UserId,
         room_id: &RoomId,
-        message_id: Option<&MessageRemoteId>,
+        message_id: Option<&MessageId>,
         payload: EncryptedPayload,
         context: Option<DecryptionContext>,
     ) -> Result<String, DecryptionError> {

--- a/crates/prose-core-client/src/domain/messaging/models/message_id.rs
+++ b/crates/prose-core-client/src/domain/messaging/models/message_id.rs
@@ -7,11 +7,20 @@ use serde::{Deserialize, Serialize};
 
 use prose_utils::id_string;
 
-// The ID assigned by a client sending the message. It is not guaranteed to be unique.
-id_string!(MessageRemoteId);
+id_string!(
+    /// The ID assigned by a client sending the message. It is not guaranteed to be unique.
+    MessageRemoteId
+);
 
-// The ID assigned by the server to the message.
-id_string!(MessageServerId);
+id_string!(
+    /// The ID assigned by the server to the message.
+    MessageServerId
+);
+
+id_string!(
+    /// The ID assigned to the message by us locally.
+    MessageId
+);
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(tag = "type", content = "id")]

--- a/crates/prose-core-client/src/domain/messaging/models/mod.rs
+++ b/crates/prose-core-client/src/domain/messaging/models/mod.rs
@@ -11,10 +11,10 @@ pub(crate) use error::StanzaParseError;
 pub use mention::Mention;
 #[allow(unused_imports)] // Reaction is required in unit tests
 pub use message::{Body, Emoji, Message, Reaction};
-pub use message_id::{MessageRemoteId, MessageServerId, MessageTargetId};
+pub use message_id::{MessageId, MessageRemoteId, MessageServerId, MessageTargetId};
 pub use message_like::{
     Body as MessageLikeBody, EncryptionInfo as MessageLikeEncryptionInfo, MessageLike,
-    MessageLikeId, Payload as MessageLikePayload,
+    Payload as MessageLikePayload,
 };
 pub use message_parser::{MessageLikeError, MessageParser};
 pub use message_ref::{ArchivedMessageRef, MessageRef};

--- a/crates/prose-core-client/src/domain/messaging/models/send_message_request.rs
+++ b/crates/prose-core-client/src/domain/messaging/models/send_message_request.rs
@@ -3,14 +3,14 @@
 // Copyright: 2024, Marc Bauer <mb@nesium.com>
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
-use super::EncryptedPayload;
 use crate::domain::shared::models::{Markdown, StyledMessage};
 
-use super::{Attachment, Mention, MessageRemoteId};
+use super::{Attachment, Mention};
+use super::{EncryptedPayload, MessageId};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SendMessageRequest {
-    pub id: MessageRemoteId,
+    pub id: MessageId,
     pub body: Option<Body>,
     pub attachments: Vec<Attachment>,
 }

--- a/crates/prose-core-client/src/domain/messaging/repos/messages_repository.rs
+++ b/crates/prose-core-client/src/domain/messaging/repos/messages_repository.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Utc};
 use prose_wasm_utils::{SendUnlessWasm, SyncUnlessWasm};
 
 use crate::domain::messaging::models::{
-    ArchivedMessageRef, MessageLike, MessageRemoteId, MessageServerId, MessageTargetId,
+    ArchivedMessageRef, MessageId, MessageLike, MessageRemoteId, MessageServerId, MessageTargetId,
 };
 use crate::domain::shared::models::{AccountId, RoomId};
 
@@ -23,14 +23,14 @@ pub trait MessagesRepository: SendUnlessWasm + SyncUnlessWasm {
         &self,
         account: &AccountId,
         room_id: &RoomId,
-        id: &MessageRemoteId,
+        id: &MessageId,
     ) -> Result<Vec<MessageLike>>;
     /// Returns all parts (MessageLike) that make up all messages in `ids`. Sorted chronologically.
     async fn get_all(
         &self,
         account: &AccountId,
         room_id: &RoomId,
-        ids: &[MessageRemoteId],
+        ids: &[MessageId],
     ) -> Result<Vec<MessageLike>>;
     /// Returns all messages that target any IDs contained in `targeted_id` and are newer
     /// than `newer_than`.
@@ -45,7 +45,7 @@ pub trait MessagesRepository: SendUnlessWasm + SyncUnlessWasm {
         &self,
         account: &AccountId,
         room_id: &RoomId,
-        id: &MessageRemoteId,
+        id: &MessageServerId,
     ) -> Result<bool>;
     async fn append(
         &self,
@@ -55,13 +55,25 @@ pub trait MessagesRepository: SendUnlessWasm + SyncUnlessWasm {
     ) -> Result<()>;
     async fn clear_cache(&self, account: &AccountId) -> Result<()>;
 
-    /// Attempts to look up the message identified by `stanza_id` and returns
-    /// its `id` if it was found.
-    async fn resolve_message_id(
+    async fn resolve_server_id_to_message_id(
         &self,
         account: &AccountId,
         room_id: &RoomId,
-        stanza_id: &MessageServerId,
+        server_id: &MessageServerId,
+    ) -> Result<Option<MessageId>>;
+
+    async fn resolve_remote_id_to_message_id(
+        &self,
+        account: &AccountId,
+        room_id: &RoomId,
+        remote_id: &MessageRemoteId,
+    ) -> Result<Option<MessageId>>;
+
+    async fn resolve_message_id_to_remote_id(
+        &self,
+        account: &AccountId,
+        room_id: &RoomId,
+        id: &MessageId,
     ) -> Result<Option<MessageRemoteId>>;
 
     /// Returns the latest message, if available, that has a `stanza_id` set and was received

--- a/crates/prose-core-client/src/domain/messaging/services/message_id_provider.rs
+++ b/crates/prose-core-client/src/domain/messaging/services/message_id_provider.rs
@@ -1,0 +1,44 @@
+// prose-core-client/prose-core-client
+//
+// Copyright: 2024, Marc Bauer <mb@nesium.com>
+// License: Mozilla Public License v2.0 (MPL v2.0)
+
+use crate::dtos::MessageId;
+use prose_xmpp::{IDProvider, UUIDProvider};
+
+pub trait MessageIdProvider: Send + Sync {
+    fn new_id(&self) -> MessageId;
+}
+
+pub struct WrappingMessageIdProvider<T: IDProvider> {
+    id_provider: T,
+}
+
+impl<T: IDProvider> WrappingMessageIdProvider<T> {
+    pub fn new(id_provider: T) -> Self {
+        Self { id_provider }
+    }
+}
+
+impl WrappingMessageIdProvider<UUIDProvider> {
+    pub fn uuid() -> Self {
+        Self {
+            id_provider: UUIDProvider::new(),
+        }
+    }
+}
+
+#[cfg(feature = "test")]
+impl WrappingMessageIdProvider<prose_xmpp::test::IncrementingIDProvider> {
+    pub fn incrementing(prefix: &str) -> Self {
+        Self {
+            id_provider: prose_xmpp::test::IncrementingIDProvider::new(prefix),
+        }
+    }
+}
+
+impl<T: IDProvider> MessageIdProvider for WrappingMessageIdProvider<T> {
+    fn new_id(&self) -> MessageId {
+        MessageId::from(self.id_provider.new_id())
+    }
+}

--- a/crates/prose-core-client/src/domain/messaging/services/mod.rs
+++ b/crates/prose-core-client/src/domain/messaging/services/mod.rs
@@ -5,12 +5,14 @@
 
 pub use message_archive_domain_service::MessageArchiveDomainService;
 pub use message_archive_service::{MessageArchiveService, MessagePage};
+pub use message_id_provider::{MessageIdProvider, WrappingMessageIdProvider};
 pub use message_migration_domain_service::MessageMigrationDomainService;
 pub use messaging_service::MessagingService;
 
 pub mod impls;
 mod message_archive_domain_service;
 mod message_archive_service;
+mod message_id_provider;
 mod message_migration_domain_service;
 mod messaging_service;
 

--- a/crates/prose-core-client/src/domain/rooms/models/room.rs
+++ b/crates/prose-core-client/src/domain/rooms/models/room.rs
@@ -202,6 +202,17 @@ impl Room {
         self.inner.details.write().statistics.needs_update = true;
     }
 
+    pub fn is_current_user(&self, account: &AccountId, participant: &ParticipantId) -> bool {
+        if self.room_id.is_muc_room() {
+            // We're generally trying to resolve OccupantIDs into UserIDs if possible.
+            // So the sender could be either/or depending on the room configuration.
+            Some(participant) == self.occupant_id().map(ParticipantId::Occupant).as_ref()
+                || participant == &ParticipantId::User(account.to_user_id())
+        } else {
+            participant == &ParticipantId::User(account.to_user_id())
+        }
+    }
+
     pub async fn update_statistics_if_needed(
         &self,
         account: &AccountId,

--- a/crates/prose-core-client/src/infra/messaging/message_record.rs
+++ b/crates/prose-core-client/src/infra/messaging/message_record.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use prose_store::prelude::*;
 
 use crate::domain::messaging::models::{
-    MessageLike, MessageLikeId, MessageLikePayload, MessageTargetId,
+    MessageId, MessageLike, MessageLikePayload, MessageTargetId,
 };
 use crate::domain::shared::models::AccountId;
 use crate::dtos::{MessageRemoteId, MessageServerId, ParticipantId, RoomId};
@@ -20,10 +20,11 @@ pub struct MessageRecord {
     pub id: String,
     pub account: AccountId,
     pub room_id: RoomId,
-    pub message_id: MessageLikeId,
-    pub message_id_target: Option<MessageRemoteId>,
-    pub stanza_id: Option<MessageServerId>,
-    pub stanza_id_target: Option<MessageServerId>,
+    pub message_id: MessageId,
+    pub remote_id: Option<MessageRemoteId>,
+    pub remote_id_target: Option<MessageRemoteId>,
+    pub server_id: Option<MessageServerId>,
+    pub server_id_target: Option<MessageServerId>,
     pub to: Option<BareJid>,
     pub from: ParticipantId,
     pub timestamp: DateTime<Utc>,
@@ -33,25 +34,28 @@ pub struct MessageRecord {
 mod columns {
     pub const ACCOUNT: &str = "account";
     pub const ROOM_ID: &str = "room_id";
-    pub const STANZA_ID: &str = "stanza_id";
-    pub const STANZA_ID_TARGET: &str = "stanza_id_target";
     pub const MESSAGE_ID: &str = "message_id";
-    pub const MESSAGE_ID_TARGET: &str = "message_id_target";
+    pub const SERVER_ID: &str = "server_id";
+    pub const SERVER_ID_TARGET: &str = "server_id_target";
+    pub const REMOTE_ID: &str = "remote_id";
+    pub const REMOTE_ID_TARGET: &str = "remote_id_target";
     pub const TIMESTAMP: &str = "timestamp";
 }
 
 define_entity!(MessageRecord, "messages",
     account_idx => { columns: [columns::ACCOUNT], unique: false },
     room_idx => { columns: [columns::ACCOUNT, columns::ROOM_ID], unique: false },
-    // Can't be unique, because stanzaId might be nil…
-    stanza_id_idx => { columns: [columns::ACCOUNT, columns::ROOM_ID, columns::STANZA_ID], unique: false },
-    stanza_id_target_idx => { columns: [columns::ACCOUNT, columns::ROOM_ID, columns::STANZA_ID_TARGET], unique: false },
     message_id_idx => { columns: [columns::ACCOUNT, columns::ROOM_ID, columns::MESSAGE_ID], unique: true },
-    message_id_target_idx => { columns: [columns::ACCOUNT, columns::ROOM_ID, columns::MESSAGE_ID_TARGET], unique: false },
+    // Can't be unique, because stanzaId might be nil…
+    server_id_idx => { columns: [columns::ACCOUNT, columns::ROOM_ID, columns::SERVER_ID], unique: false },
+    server_id_target_idx => { columns: [columns::ACCOUNT, columns::ROOM_ID, columns::SERVER_ID_TARGET], unique: false },
+    // Can't be unique, because remote ids are not guaranteed to be unique…
+    remote_id_idx => { columns: [columns::ACCOUNT, columns::ROOM_ID, columns::REMOTE_ID], unique: false },
+    remote_id_target_idx => { columns: [columns::ACCOUNT, columns::ROOM_ID, columns::REMOTE_ID_TARGET], unique: false },
     timestamp_idx => { columns: [columns::ACCOUNT, columns::ROOM_ID, columns::TIMESTAMP], unique: false }
 );
 
-impl KeyType for MessageLikeId {
+impl KeyType for MessageId {
     fn to_raw_key(&self) -> RawKey {
         RawKey::Text(self.to_string())
     }
@@ -84,9 +88,10 @@ impl MessageRecord {
             room_id,
             id,
             message_id: value.id,
-            message_id_target,
-            stanza_id: value.stanza_id,
-            stanza_id_target,
+            remote_id: value.remote_id,
+            remote_id_target: message_id_target,
+            server_id: value.server_id,
+            server_id_target: stanza_id_target,
             to: value.to,
             from: value.from,
             timestamp: value.timestamp,
@@ -97,7 +102,7 @@ impl MessageRecord {
 
 impl From<MessageRecord> for MessageLike {
     fn from(value: MessageRecord) -> Self {
-        let target = match (value.stanza_id_target, value.message_id_target) {
+        let target = match (value.server_id_target, value.remote_id_target) {
             (Some(id), _) => Some(MessageTargetId::ServerId(id)),
             (_, Some(id)) => Some(MessageTargetId::RemoteId(id)),
             (None, None) => None,
@@ -105,7 +110,8 @@ impl From<MessageRecord> for MessageLike {
 
         Self {
             id: value.message_id,
-            stanza_id: value.stanza_id,
+            remote_id: value.remote_id,
+            server_id: value.server_id,
             target,
             to: value.to,
             from: value.from,

--- a/crates/prose-core-client/tests/message_parsing/message_parser.rs
+++ b/crates/prose-core-client/tests/message_parsing/message_parser.rs
@@ -49,6 +49,7 @@ async fn test_parse_chat_message() -> Result<()> {
         .add_references([reference]);
 
     let parsed_message = MessageParser::new(
+        "local-id-1".into(),
         None,
         Default::default(),
         Arc::new(MockEncryptionDomainService::new()),
@@ -59,8 +60,9 @@ async fn test_parse_chat_message() -> Result<()> {
 
     assert_eq!(
         MessageLike {
-            id: "message-id-1".into(),
-            stanza_id: None,
+            id: "local-id-1".into(),
+            remote_id: Some("message-id-1".into()),
+            server_id: None,
             target: None,
             to: Some(bare!("me@prose.org")),
             from: ParticipantId::User(user_id!("them@prose.org")),
@@ -99,6 +101,7 @@ async fn test_parse_groupchat_message() -> Result<()> {
         });
 
     let parsed_message = MessageParser::new(
+        "local-id-1".into(),
         None,
         Default::default(),
         Arc::new(MockEncryptionDomainService::new()),
@@ -109,8 +112,9 @@ async fn test_parse_groupchat_message() -> Result<()> {
 
     assert_eq!(
         MessageLike {
-            id: "message-id-1".into(),
-            stanza_id: Some("dekEV-gtF2hrg_iekCjPAlON".into()),
+            id: "local-id-1".into(),
+            remote_id: Some("message-id-1".into()),
+            server_id: Some("dekEV-gtF2hrg_iekCjPAlON".into()),
             target: None,
             to: Some(bare!("me@prose.org")),
             from: ParticipantId::Occupant(occupant_id!("room@groups.prose.org/them")),
@@ -152,6 +156,7 @@ async fn test_parse_sent_carbon_message() -> Result<()> {
     });
 
     let parsed_message = MessageParser::new(
+        "local-id-1".into(),
         None,
         Default::default(),
         Arc::new(MockEncryptionDomainService::new()),
@@ -162,8 +167,9 @@ async fn test_parse_sent_carbon_message() -> Result<()> {
 
     assert_eq!(
         MessageLike {
-            id: "message-id-1".into(),
-            stanza_id: Some("Qiuahv1eo3C222uKhOqjPiW0".into()),
+            id: "local-id-1".into(),
+            remote_id: Some("message-id-1".into()),
+            server_id: Some("Qiuahv1eo3C222uKhOqjPiW0".into()),
             target: None,
             to: Some(bare!("them@prose.org")),
             from: ParticipantId::User(user_id!("me@prose.org")),
@@ -208,6 +214,7 @@ async fn test_parse_mam_groupchat_message() -> Result<()> {
     };
 
     let parsed_message = MessageParser::new(
+        "local-id-1".into(),
         None,
         Default::default(),
         Arc::new(MockEncryptionDomainService::new()),
@@ -218,8 +225,9 @@ async fn test_parse_mam_groupchat_message() -> Result<()> {
 
     assert_eq!(
         MessageLike {
-            id: "message-id-1".into(),
-            stanza_id: Some("FbGQI-iEUNysr8pdD2PP9mmU".into()),
+            id: "local-id-1".into(),
+            remote_id: Some("message-id-1".into()),
+            server_id: Some("FbGQI-iEUNysr8pdD2PP9mmU".into()),
             target: None,
             to: Some(bare!("me@prose.org")),
             from: ParticipantId::Occupant(occupant_id!("room@groups.prose.org/them")),
@@ -269,6 +277,7 @@ async fn test_parse_mam_groupchat_message_with_real_jid() -> Result<()> {
     };
 
     let parsed_message = MessageParser::new(
+        "local-id-1".into(),
         None,
         Default::default(),
         Arc::new(MockEncryptionDomainService::new()),
@@ -280,8 +289,9 @@ async fn test_parse_mam_groupchat_message_with_real_jid() -> Result<()> {
     assert_eq!(
         parsed_message,
         MessageLike {
-            id: "message-id-1".into(),
-            stanza_id: Some("FbGQI-iEUNysr8pdD2PP9mmU".into()),
+            id: "local-id-1".into(),
+            remote_id: Some("message-id-1".into()),
+            server_id: Some("FbGQI-iEUNysr8pdD2PP9mmU".into()),
             target: None,
             to: Some(bare!("me@prose.org")),
             from: ParticipantId::User(user_id!("them@prose.org")),
@@ -325,6 +335,7 @@ async fn test_parse_mam_chat_message() -> Result<()> {
     };
 
     let parsed_message = MessageParser::new(
+        "local-id-1".into(),
         None,
         Default::default(),
         Arc::new(MockEncryptionDomainService::new()),
@@ -335,8 +346,9 @@ async fn test_parse_mam_chat_message() -> Result<()> {
 
     assert_eq!(
         MessageLike {
-            id: "message-id-1".into(),
-            stanza_id: Some("bne6LtG1ev_jIb1oYNA7nxip".into()),
+            id: "local-id-1".into(),
+            remote_id: Some("message-id-1".into()),
+            server_id: Some("bne6LtG1ev_jIb1oYNA7nxip".into()),
             target: None,
             to: Some(bare!("me@prose.org")),
             from: ParticipantId::User(user_id!("them@prose.org")),
@@ -377,6 +389,7 @@ async fn test_parse_delayed_message() -> Result<()> {
         .set_body("Hello");
 
     let parsed_message = MessageParser::new(
+        "local-id-1".into(),
         None,
         Default::default(),
         Arc::new(MockEncryptionDomainService::new()),
@@ -387,8 +400,9 @@ async fn test_parse_delayed_message() -> Result<()> {
 
     assert_eq!(
         MessageLike {
-            id: "message-id-1".into(),
-            stanza_id: None,
+            id: "local-id-1".into(),
+            remote_id: Some("message-id-1".into()),
+            server_id: None,
             target: None,
             to: Some(bare!("me@prose.org")),
             from: ParticipantId::User(user_id!("them@prose.org")),
@@ -422,6 +436,7 @@ async fn test_message_with_attachment_and_empty_body() -> Result<()> {
     }]);
 
     let parsed_message = MessageParser::new(
+        "local-id-1".into(),
         None,
         Default::default(),
         Arc::new(MockEncryptionDomainService::new()),
@@ -432,8 +447,9 @@ async fn test_message_with_attachment_and_empty_body() -> Result<()> {
 
     assert_eq!(
         MessageLike {
-            id: "message-id-1".into(),
-            stanza_id: None,
+            id: "local-id-1".into(),
+            remote_id: Some("message-id-1".into()),
+            server_id: None,
             target: None,
             to: Some(bare!("me@prose.org")),
             from: ParticipantId::User(user_id!("them@prose.org")),

--- a/crates/prose-core-client/tests/messages_event_handler.rs
+++ b/crates/prose-core-client/tests/messages_event_handler.rs
@@ -18,14 +18,19 @@ use prose_core_client::domain::connection::models::ConnectionProperties;
 use prose_core_client::domain::messaging::models::{
     MessageLike, MessageLikeBody, MessageLikePayload,
 };
+use prose_core_client::domain::messaging::services::WrappingMessageIdProvider;
 use prose_core_client::domain::rooms::models::{Room, RoomInfo};
 use prose_core_client::domain::shared::models::{
     MucId, OccupantId, RoomId, RoomType, UserId, UserResourceId,
 };
-use prose_core_client::dtos::{Availability, MessageRemoteId, MessageServerId, ParticipantId};
+use prose_core_client::dtos::{
+    Availability, MessageId, MessageRemoteId, MessageServerId, ParticipantId,
+};
+use prose_core_client::test::mock_data::account_jid;
 use prose_core_client::test::{ConstantTimeProvider, MockAppDependencies};
 use prose_core_client::{muc_id, occupant_id, user_id, user_resource_id, ClientRoomEventType};
 use prose_xmpp::mods::chat::Carbon;
+use prose_xmpp::stanza::message::stanza_id::StanzaId;
 use prose_xmpp::stanza::message::{Forwarded, Reactions};
 use prose_xmpp::stanza::muc::MucUser;
 use prose_xmpp::stanza::Message;
@@ -34,9 +39,21 @@ use prose_xmpp::{bare, full, jid};
 #[tokio::test]
 async fn test_receiving_message_adds_item_to_sidebar_if_needed() -> Result<()> {
     let mut deps = MockAppDependencies::default();
+    deps.message_id_provider = Arc::new(WrappingMessageIdProvider::incrementing("msg-id"));
     let mut seq = Sequence::new();
 
     let room = Room::group(muc_id!("group@conference.prose.org")).with_name("Group Name");
+
+    deps.messages_repo
+        .expect_contains()
+        .once()
+        .in_sequence(&mut seq)
+        .with(
+            predicate::always(),
+            predicate::always(),
+            predicate::eq(MessageServerId::from("message-id")),
+        )
+        .return_once(|_, _, _| Box::pin(async { Ok(false) }));
 
     {
         let room = room.clone();
@@ -77,17 +94,6 @@ async fn test_receiving_message_adds_item_to_sidebar_if_needed() -> Result<()> {
         .return_once(|_, _| Box::pin(async { Ok(()) }));
 
     deps.messages_repo
-        .expect_contains()
-        .once()
-        .in_sequence(&mut seq)
-        .with(
-            predicate::always(),
-            predicate::always(),
-            predicate::eq(MessageRemoteId::from("message-id")),
-        )
-        .return_once(|_, _, _| Box::pin(async { Ok(false) }));
-
-    deps.messages_repo
         .expect_append()
         .once()
         .in_sequence(&mut seq)
@@ -100,7 +106,7 @@ async fn test_receiving_message_adds_item_to_sidebar_if_needed() -> Result<()> {
         .with(
             predicate::eq(room),
             predicate::eq(ClientRoomEventType::MessagesAppended {
-                message_ids: vec!["message-id".into()],
+                message_ids: vec!["msg-id-1".into()],
             }),
         )
         .return_once(|_, _| ());
@@ -111,7 +117,11 @@ async fn test_receiving_message_adds_item_to_sidebar_if_needed() -> Result<()> {
             r#type: MessageEventType::Received(
                 Message::default()
                     .set_type(MessageType::Groupchat)
-                    .set_id("message-id".into())
+                    .set_to(bare!("group@conference.prose.org"))
+                    .set_stanza_id(StanzaId {
+                        id: "message-id".into(),
+                        by: bare!("group@conference.prose.org").into(),
+                    })
                     .set_from(jid!("group@conference.prose.org/user"))
                     .set_body("Hello World"),
             ),
@@ -124,6 +134,7 @@ async fn test_receiving_message_adds_item_to_sidebar_if_needed() -> Result<()> {
 #[tokio::test]
 async fn test_receiving_message_from_new_contact_creates_room() -> Result<()> {
     let mut deps = MockAppDependencies::default();
+    deps.message_id_provider = Arc::new(WrappingMessageIdProvider::incrementing("msg-id"));
     let mut seq = Sequence::new();
 
     let room = Room::direct_message(user_id!("jane.doe@prose.org"), Availability::Unavailable);
@@ -159,7 +170,7 @@ async fn test_receiving_message_from_new_contact_creates_room() -> Result<()> {
         .with(
             predicate::always(),
             predicate::always(),
-            predicate::eq(MessageRemoteId::from("message-id")),
+            predicate::eq(MessageServerId::from("message-id")),
         )
         .return_once(|_, _, _| Box::pin(async { Ok(false) }));
 
@@ -176,7 +187,7 @@ async fn test_receiving_message_from_new_contact_creates_room() -> Result<()> {
         .with(
             predicate::eq(room),
             predicate::eq(ClientRoomEventType::MessagesAppended {
-                message_ids: vec!["message-id".into()],
+                message_ids: vec!["msg-id-1".into()],
             }),
         )
         .return_once(|_, _| ());
@@ -187,7 +198,11 @@ async fn test_receiving_message_from_new_contact_creates_room() -> Result<()> {
             r#type: MessageEventType::Received(
                 Message::default()
                     .set_type(MessageType::Chat)
-                    .set_id("message-id".into())
+                    .set_to(account_jid())
+                    .set_stanza_id(StanzaId {
+                        id: "message-id".into(),
+                        by: bare!("jane.doe@prose.org").into(),
+                    })
                     .set_from(jid!("jane.doe@prose.org"))
                     .set_body("Hello World"),
             ),
@@ -200,6 +215,7 @@ async fn test_receiving_message_from_new_contact_creates_room() -> Result<()> {
 #[tokio::test]
 async fn test_parses_user_id_from_in_sent_groupchat_message() -> Result<()> {
     let mut deps = MockAppDependencies::default();
+    deps.message_id_provider = Arc::new(WrappingMessageIdProvider::incrementing("msg-id"));
     let mut seq = Sequence::new();
 
     *deps.ctx.connection_properties.write() = Some(ConnectionProperties {
@@ -212,9 +228,13 @@ async fn test_parses_user_id_from_in_sent_groupchat_message() -> Result<()> {
 
     let room = Room::group(muc_id!("room@conference.prose.org"));
 
-    let sent_message = prose_xmpp::stanza::Message::new()
+    let sent_message = Message::new()
         .set_type(MessageType::Groupchat)
         .set_id("message-id".into())
+        .set_stanza_id(StanzaId {
+            id: "stanza-id".into(),
+            by: bare!("room@conference.prose.org").into(),
+        })
         .set_from(full!("from@prose.org/res"))
         .set_to(bare!("room@conference.prose.org"))
         .set_body("Hello World")
@@ -222,8 +242,9 @@ async fn test_parses_user_id_from_in_sent_groupchat_message() -> Result<()> {
         .set_markable();
 
     let expected_saved_message = MessageLike {
-        id: "message-id".into(),
-        stanza_id: None,
+        id: "msg-id-1".into(),
+        remote_id: Some("message-id".into()),
+        server_id: Some("stanza-id".into()),
         target: None,
         to: Some(bare!("room@conference.prose.org")),
         from: ParticipantId::User(user_id!("from@prose.org")), // Resource should be dropped
@@ -260,10 +281,20 @@ async fn test_parses_user_id_from_in_sent_groupchat_message() -> Result<()> {
         .with(
             predicate::always(),
             predicate::always(),
-            predicate::eq(MessageRemoteId::from("message-id")),
+            predicate::eq(MessageServerId::from("stanza-id")),
         )
         .once()
         .return_once(|_, _, _| Box::pin(async { Ok(false) }));
+
+    deps.messages_repo
+        .expect_resolve_remote_id_to_message_id()
+        .with(
+            predicate::always(),
+            predicate::always(),
+            predicate::eq(MessageRemoteId::from("message-id")),
+        )
+        .once()
+        .return_once(|_, _, _| Box::pin(async { Ok(None) }));
 
     deps.messages_repo
         .expect_append()
@@ -283,7 +314,7 @@ async fn test_parses_user_id_from_in_sent_groupchat_message() -> Result<()> {
         .with(
             predicate::eq(room),
             predicate::eq(ClientRoomEventType::MessagesAppended {
-                message_ids: vec!["message-id".into()],
+                message_ids: vec!["msg-id-1".into()],
             }),
         )
         .return_once(|_, _| ());
@@ -302,6 +333,7 @@ async fn test_parses_user_id_from_in_sent_groupchat_message() -> Result<()> {
 async fn test_parses_private_message_in_muc_room() -> Result<()> {
     let mut deps = MockAppDependencies::default();
     let mut seq = Sequence::new();
+    deps.message_id_provider = Arc::new(WrappingMessageIdProvider::incrementing("msg-id"));
 
     *deps.ctx.connection_properties.write() = Some(ConnectionProperties {
         connection_timestamp: Default::default(),
@@ -313,17 +345,22 @@ async fn test_parses_private_message_in_muc_room() -> Result<()> {
 
     let room = Room::group(muc_id!("room@conference.prose.org"));
 
-    let received_message = prose_xmpp::stanza::Message::new()
+    let received_message = Message::new()
         .set_type(MessageType::Chat)
         .set_id("message-id".into())
+        .set_stanza_id(StanzaId {
+            id: "stanza-id".into(),
+            by: bare!("room@conference.prose.org").into(),
+        })
         .set_from(full!("room@conference.prose.org/other-user"))
         .set_to(full!("user@prose.org/res"))
         .set_body("Private Message")
         .add_payload(MucUser::new());
 
     let expected_saved_message = MessageLike {
-        id: "message-id".into(),
-        stanza_id: None,
+        id: "msg-id-1".into(),
+        remote_id: Some("message-id".into()),
+        server_id: Some("stanza-id".into()),
         target: None,
         to: Some(bare!("user@prose.org")),
         from: ParticipantId::Occupant(occupant_id!("room@conference.prose.org/other-user")),
@@ -384,7 +421,7 @@ async fn test_parses_private_message_in_muc_room() -> Result<()> {
         .with(
             predicate::eq(room),
             predicate::eq(ClientRoomEventType::MessagesAppended {
-                message_ids: vec!["message-id".into()],
+                message_ids: vec!["msg-id-1".into()],
             }),
         )
         .return_once(|_, _| ());
@@ -402,6 +439,7 @@ async fn test_parses_private_message_in_muc_room() -> Result<()> {
 #[tokio::test]
 async fn test_dispatches_messages_appended_for_new_received_message() -> Result<()> {
     let mut deps = MockAppDependencies::default();
+    deps.message_id_provider = Arc::new(WrappingMessageIdProvider::incrementing("msg-id"));
 
     let room = Room::group(muc_id!("user@prose.org"));
 
@@ -432,7 +470,7 @@ async fn test_dispatches_messages_appended_for_new_received_message() -> Result<
         .with(
             predicate::eq(room),
             predicate::eq(ClientRoomEventType::MessagesAppended {
-                message_ids: vec!["message-id".into()],
+                message_ids: vec!["msg-id-1".into()],
             }),
         )
         .return_once(|_, _| ());
@@ -442,7 +480,11 @@ async fn test_dispatches_messages_appended_for_new_received_message() -> Result<
         .handle_event(ServerEvent::Message(MessageEvent {
             r#type: MessageEventType::Received(
                 Message::default()
-                    .set_id("message-id".into())
+                    .set_to(account_jid())
+                    .set_stanza_id(StanzaId {
+                        id: "stanza-id".into(),
+                        by: bare!("user@prose.org").into(),
+                    })
                     .set_from(jid!("user@prose.org"))
                     .set_body("Hello World"),
             ),
@@ -455,6 +497,7 @@ async fn test_dispatches_messages_appended_for_new_received_message() -> Result<
 #[tokio::test]
 async fn test_dispatches_messages_appended_for_sent_carbon() -> Result<()> {
     let mut deps = MockAppDependencies::default();
+    deps.message_id_provider = Arc::new(WrappingMessageIdProvider::incrementing("msg-id"));
 
     *deps.ctx.connection_properties.write() = Some(ConnectionProperties {
         connection_timestamp: Default::default(),
@@ -481,10 +524,20 @@ async fn test_dispatches_messages_appended_for_sent_carbon() -> Result<()> {
         .with(
             predicate::always(),
             predicate::always(),
-            predicate::eq(MessageRemoteId::from("message-id")),
+            predicate::eq(MessageServerId::from("Qiuahv1eo3C222uKhOqjPiW0")),
         )
         .once()
         .return_once(|_, _, _| Box::pin(async { Ok(false) }));
+
+    deps.messages_repo
+        .expect_resolve_remote_id_to_message_id()
+        .with(
+            predicate::always(),
+            predicate::always(),
+            predicate::eq(MessageRemoteId::from("message-id")),
+        )
+        .once()
+        .return_once(|_, _, _| Box::pin(async { Ok(None) }));
 
     deps.messages_repo
         .expect_append()
@@ -496,7 +549,7 @@ async fn test_dispatches_messages_appended_for_sent_carbon() -> Result<()> {
         .with(
             predicate::eq(room),
             predicate::eq(ClientRoomEventType::MessagesAppended {
-                message_ids: vec!["message-id".into()],
+                message_ids: vec!["msg-id-1".into()],
             }),
         )
         .return_once(|_, _| ());
@@ -514,7 +567,7 @@ async fn test_dispatches_messages_appended_for_sent_carbon() -> Result<()> {
                         .set_to(bare!("user@prose.org"))
                         .set_body("Hello World")
                         .set_chat_state(Some(ChatState::Active))
-                        .set_stanza_id(prose_xmpp::stanza::message::stanza_id::StanzaId {
+                        .set_stanza_id(StanzaId {
                             id: "Qiuahv1eo3C222uKhOqjPiW0".into(),
                             by: bare!("user@prose.org").into(),
                         }),
@@ -531,6 +584,7 @@ async fn test_dispatches_messages_appended_for_sent_carbon() -> Result<()> {
 #[tokio::test]
 async fn test_dispatches_messages_appended_for_muc_carbon() -> Result<()> {
     let mut deps = MockAppDependencies::default();
+    deps.message_id_provider = Arc::new(WrappingMessageIdProvider::incrementing("msg-id"));
 
     let room = Room::mock(RoomInfo {
         room_id: RoomId::Muc(muc_id!("room@groups.prose.org")),
@@ -558,10 +612,20 @@ async fn test_dispatches_messages_appended_for_muc_carbon() -> Result<()> {
         .with(
             predicate::always(),
             predicate::always(),
-            predicate::eq(MessageRemoteId::from("message-id")),
+            predicate::eq(MessageServerId::from("Qiuahv1eo3C222uKhOqjPiW0")),
         )
         .once()
         .return_once(|_, _, _| Box::pin(async { Ok(false) }));
+
+    deps.messages_repo
+        .expect_resolve_remote_id_to_message_id()
+        .with(
+            predicate::always(),
+            predicate::always(),
+            predicate::eq(MessageRemoteId::from("message-id")),
+        )
+        .once()
+        .return_once(|_, _, _| Box::pin(async { Ok(None) }));
 
     deps.messages_repo
         .expect_append()
@@ -573,7 +637,7 @@ async fn test_dispatches_messages_appended_for_muc_carbon() -> Result<()> {
         .with(
             predicate::eq(room),
             predicate::eq(ClientRoomEventType::MessagesAppended {
-                message_ids: vec!["message-id".into()],
+                message_ids: vec!["msg-id-1".into()],
             }),
         )
         .return_once(|_, _| ());
@@ -605,11 +669,6 @@ async fn test_dispatches_messages_updated_for_existing_received_message() -> Res
 
     let room = Room::group(muc_id!("user@prose.org"));
 
-    deps.sidebar_domain_service
-        .expect_handle_received_message()
-        .once()
-        .return_once(|_, _| Box::pin(async { Ok(()) }));
-
     {
         let room = room.clone();
         deps.connected_rooms_repo
@@ -626,17 +685,6 @@ async fn test_dispatches_messages_updated_for_existing_received_message() -> Res
         .expect_append()
         .return_once(|_, _, _| Box::pin(async { Ok(()) }));
 
-    deps.client_event_dispatcher
-        .expect_dispatch_room_event()
-        .once()
-        .with(
-            predicate::eq(room),
-            predicate::eq(ClientRoomEventType::MessagesUpdated {
-                message_ids: vec!["message-id".into()],
-            }),
-        )
-        .return_once(|_, _| ());
-
     let event_handler = MessagesEventHandler::from(&deps.into_deps());
     event_handler
         .handle_event(ServerEvent::Message(MessageEvent {
@@ -644,6 +692,11 @@ async fn test_dispatches_messages_updated_for_existing_received_message() -> Res
                 Message::default()
                     .set_id("message-id".into())
                     .set_from(jid!("user@prose.org"))
+                    .set_to(account_jid())
+                    .set_stanza_id(StanzaId {
+                        id: "stanza-id".into(),
+                        by: bare!("user@prose.org").into(),
+                    })
                     .set_body("Hello World"),
             ),
         }))
@@ -677,15 +730,13 @@ async fn test_looks_up_message_id_when_dispatching_message_event() -> Result<()>
         .return_once(|_, _, _| Box::pin(async { Ok(()) }));
 
     deps.messages_repo
-        .expect_resolve_message_id()
+        .expect_resolve_server_id_to_message_id()
         .with(
             predicate::always(),
             predicate::eq(RoomId::Muc(muc_id!("group@prose.org"))),
             predicate::eq(MessageServerId::from("stanza-id-100")),
         )
-        .return_once(|_, _, _| {
-            Box::pin(async { Ok(Some(MessageRemoteId::from("message-id-100"))) })
-        });
+        .return_once(|_, _, _| Box::pin(async { Ok(Some(MessageId::from("message-id-100"))) }));
 
     deps.client_event_dispatcher
         .expect_dispatch_room_event()
@@ -706,6 +757,11 @@ async fn test_looks_up_message_id_when_dispatching_message_event() -> Result<()>
                     .set_id("message-id".into())
                     .set_type(MessageType::Groupchat)
                     .set_from(jid!("group@prose.org/user"))
+                    .set_to(bare!("group@prose.org"))
+                    .set_stanza_id(StanzaId {
+                        id: "stanza-id".into(),
+                        by: bare!("group@prose.org").into(),
+                    })
                     .set_message_reactions(Reactions {
                         id: "stanza-id-100".to_string(),
                         reactions: vec!["🙃".into()],
@@ -737,10 +793,20 @@ async fn test_looks_up_message_id_for_sent_groupchat_messages_when_dispatching_m
         .with(
             predicate::always(),
             predicate::always(),
-            predicate::eq(MessageRemoteId::from("message-id")),
+            predicate::eq(MessageServerId::from("stanza-id")),
         )
         .once()
         .return_once(|_, _, _| Box::pin(async { Ok(false) }));
+
+    deps.messages_repo
+        .expect_resolve_remote_id_to_message_id()
+        .with(
+            predicate::always(),
+            predicate::always(),
+            predicate::eq(MessageRemoteId::from("message-id")),
+        )
+        .once()
+        .return_once(|_, _, _| Box::pin(async { Ok(None) }));
 
     deps.messages_repo
         .expect_append()
@@ -748,15 +814,13 @@ async fn test_looks_up_message_id_for_sent_groupchat_messages_when_dispatching_m
         .return_once(|_, _, _| Box::pin(async { Ok(()) }));
 
     deps.messages_repo
-        .expect_resolve_message_id()
+        .expect_resolve_server_id_to_message_id()
         .with(
             predicate::always(),
             predicate::eq(RoomId::Muc(muc_id!("group@prose.org"))),
             predicate::eq(MessageServerId::from("stanza-id-100")),
         )
-        .return_once(|_, _, _| {
-            Box::pin(async { Ok(Some(MessageRemoteId::from("message-id-100"))) })
-        });
+        .return_once(|_, _, _| Box::pin(async { Ok(Some(MessageId::from("message-id-100"))) }));
 
     deps.client_event_dispatcher
         .expect_dispatch_room_event()
@@ -775,6 +839,10 @@ async fn test_looks_up_message_id_for_sent_groupchat_messages_when_dispatching_m
             r#type: MessageEventType::Sent(
                 Message::default()
                     .set_id("message-id".into())
+                    .set_stanza_id(StanzaId {
+                        id: "stanza-id".into(),
+                        by: bare!("user@prose.org").into(),
+                    })
                     .set_type(MessageType::Groupchat)
                     .set_from(full!("from@prose.org/res"))
                     .set_to(jid!("group@prose.org"))

--- a/crates/prose-utils/src/id_string_macro.rs
+++ b/crates/prose-utils/src/id_string_macro.rs
@@ -5,7 +5,8 @@
 
 #[macro_export]
 macro_rules! id_string {
-    ($t:ident) => {
+    ($(#[$meta:meta])* $t:ident) => {
+        $(#[$meta])*
         #[derive(Debug, Eq, PartialEq, Hash, Clone, serde::Serialize, serde::Deserialize)]
         #[serde(transparent)]
         pub struct $t(String);
@@ -32,8 +33,14 @@ macro_rules! id_string {
             }
         }
 
+        impl std::borrow::Borrow<str> for $t {
+            fn borrow(&self) -> &str {
+                &self.0
+            }
+        }
+
         impl std::str::FromStr for $t {
-            type Err = ();
+            type Err = std::convert::Infallible;
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 Ok($t(s.to_string()))

--- a/crates/prose-xmpp/src/mods/muc/join_room_future.rs
+++ b/crates/prose-xmpp/src/mods/muc/join_room_future.rs
@@ -1,0 +1,130 @@
+// prose-core-client/prose-xmpp
+//
+// Copyright: 2024, Marc Bauer <mb@nesium.com>
+// License: Mozilla Public License v2.0 (MPL v2.0)
+
+use jid::FullJid;
+use xmpp_parsers::presence;
+use xmpp_parsers::presence::Presence;
+use xmpp_parsers::stanza_error::StanzaError;
+
+use crate::stanza::Message;
+use crate::util::{ElementReducerPoll, RequestFuture, XMPPElement};
+use crate::RequestError;
+
+/// Order of events (https://xmpp.org/extensions/xep-0045.html#order)
+///   1. In-room presence from other occupants
+///   2. In-room presence from the joining entity itself (so-called "self-presence")
+///   3. Room history (if any)
+///   4. The room subject
+///   5. Live messages, presence updates, new user joins, etc.
+pub struct JoinRoomState {
+    room_jid: FullJid,
+    presences: Vec<Presence>,
+    self_presence: Option<Presence>,
+    subject: Option<String>,
+    message_history: Vec<Message>,
+}
+
+impl RequestFuture<JoinRoomState, (Presence, Vec<Presence>, Vec<Message>, Option<String>)> {
+    pub fn new_join_room_request(room_jid: FullJid) -> Self {
+        let room_bare_jid = room_jid.to_bare();
+
+        RequestFuture::new(
+            format!("MUC {room_jid}"),
+            JoinRoomState {
+                room_jid,
+                presences: vec![],
+                self_presence: None,
+                subject: None,
+                message_history: vec![],
+            },
+            move |state, element| {
+                match element {
+                    XMPPElement::Presence(presence) => {
+                        let Some(from) = &presence
+                            .from
+                            .as_ref()
+                            .and_then(|from| from.try_as_full().ok())
+                        else {
+                            return Ok(ElementReducerPoll::Pending(Some(presence.into())));
+                        };
+
+                        // Make sure that the presence is actually sent by our room…
+                        if from.to_bare() != room_bare_jid {
+                            return Ok(ElementReducerPoll::Pending(Some(presence.into())));
+                        }
+
+                        // Is that the self-presence or somebody else's?
+                        let is_self_presence = from.resource() == state.room_jid.resource();
+
+                        // Check if we have an error on our hands (which is addressed at us directly)…
+                        if presence.type_ == presence::Type::Error && is_self_presence {
+                            return if let Some(error_payload) =
+                                presence.payloads.iter().find(|p| p.name() == "error")
+                            {
+                                match StanzaError::try_from(error_payload.clone()) {
+                                    Ok(err) => Err(RequestError::XMPP { err }),
+                                    Err(error) => Err(RequestError::Generic {
+                                        msg: error.to_string(),
+                                    }),
+                                }
+                            } else {
+                                Err(RequestError::Generic {
+                                    msg:
+                                    "Encountered presence of type error with a missing `error` stanza."
+                                        .to_string(),
+                                })
+                            };
+                        }
+
+                        if is_self_presence {
+                            state.self_presence = Some(presence.clone());
+                        } else {
+                            state.presences.push(presence.clone());
+                        }
+
+                        Ok(ElementReducerPoll::Pending(None))
+                    }
+                    XMPPElement::Message(message) => {
+                        // Make sure that the message is actually sent by our room and is
+                        // not a MAM message. Otherwise, we might run into a situation where - when
+                        // a MAM request is performed at the same time as we're connecting to the
+                        // same room - we're consuming all messages from the MAM request.
+                        if message.from.as_ref().map(|jid| jid.to_bare()).as_ref()
+                            != Some(&room_bare_jid)
+                            || message.is_mam_message()
+                        {
+                            return Ok(ElementReducerPoll::Pending(Some(message.into())));
+                        }
+
+                        if let Some(subject) = message.subject() {
+                            // We're done…
+                            state.subject = (!subject.is_empty()).then_some(subject.to_string());
+                            return Ok(ElementReducerPoll::Ready);
+                        }
+
+                        state.message_history.push(message.clone());
+                        Ok(ElementReducerPoll::Pending(None))
+                    }
+                    XMPPElement::IQ(_) | XMPPElement::PubSubMessage(_) => {
+                        Ok(ElementReducerPoll::Pending(Some(element)))
+                    }
+                }
+            },
+            |state| {
+                (
+                    state.self_presence.unwrap_or_else(|| {
+                        panic!(
+                            "Internal error. Missing response in JoinRoomState for room {}.",
+                            state.room_jid
+                        )
+                    }),
+                    state.presences,
+                    state.message_history,
+                    state.subject,
+                )
+            },
+        )
+    }
+}

--- a/crates/prose-xmpp/src/mods/muc/mod.rs
+++ b/crates/prose-xmpp/src/mods/muc/mod.rs
@@ -30,6 +30,7 @@ use crate::stanza::{muc, Message};
 use crate::util::{RequestError, RequestFuture};
 
 mod join_room_future;
+mod send_muc_message_future;
 
 /// XEP-0045: Multi-User Chat
 /// https://xmpp.org/extensions/xep-0045.html#disco-rooms
@@ -105,6 +106,22 @@ impl Module for MUC {
 }
 
 impl MUC {
+    pub async fn send_raw_message(&self, message: Message) -> Result<Message, RequestError> {
+        let room_jid = message
+            .to
+            .clone()
+            .expect("Missing `to` in MUC message")
+            .into_bare();
+        let message_id = message.id.clone().expect("Missing `id` in MUC message");
+
+        self.ctx
+            .send_stanza_with_future(
+                message,
+                RequestFuture::new_send_muc_message(room_jid, message_id),
+            )
+            .await
+    }
+
     /// Loads public rooms in a MUC service.
     /// https://xmpp.org/extensions/xep-0045.html#disco-rooms
     pub async fn load_public_rooms(&self, service: &BareJid) -> Result<Vec<Room>> {

--- a/crates/prose-xmpp/src/mods/muc/mod.rs
+++ b/crates/prose-xmpp/src/mods/muc/mod.rs
@@ -16,7 +16,6 @@ use xmpp_parsers::muc::user::{Affiliation, Status};
 use xmpp_parsers::nick::Nick;
 use xmpp_parsers::presence;
 use xmpp_parsers::presence::{Presence, Show};
-use xmpp_parsers::stanza_error::StanzaError;
 
 use prose_wasm_utils::SendUnlessWasm;
 
@@ -28,7 +27,9 @@ use crate::stanza::muc::mediated_invite::MediatedInvite;
 use crate::stanza::muc::query::{Destroy, Role};
 use crate::stanza::muc::{DirectInvite, MucUser, Query};
 use crate::stanza::{muc, Message};
-use crate::util::{ElementReducerPoll, RequestError, RequestFuture, XMPPElement};
+use crate::util::{RequestError, RequestFuture};
+
+mod join_room_future;
 
 /// XEP-0045: Multi-User Chat
 /// https://xmpp.org/extensions/xep-0045.html#disco-rooms
@@ -465,122 +466,5 @@ impl MUC {
             subject,
             message_history,
         })
-    }
-}
-
-/// Order of events (https://xmpp.org/extensions/xep-0045.html#order)
-///   1. In-room presence from other occupants
-///   2. In-room presence from the joining entity itself (so-called "self-presence")
-///   3. Room history (if any)
-///   4. The room subject
-///   5. Live messages, presence updates, new user joins, etc.
-struct JoinRoomState {
-    pub room_jid: FullJid,
-    pub presences: Vec<Presence>,
-    pub self_presence: Option<Presence>,
-    pub subject: Option<String>,
-    pub message_history: Vec<Message>,
-}
-
-impl RequestFuture<JoinRoomState, (Presence, Vec<Presence>, Vec<Message>, Option<String>)> {
-    pub fn new_join_room_request(room_jid: FullJid) -> Self {
-        let room_bare_jid = room_jid.to_bare();
-
-        RequestFuture::new(
-            format!("MUC {room_jid}"),
-            JoinRoomState {
-                room_jid,
-                presences: vec![],
-                self_presence: None,
-                subject: None,
-                message_history: vec![],
-            },
-            move |state, element| {
-                match element {
-                    XMPPElement::Presence(presence) => {
-                        let Some(from) = &presence
-                            .from
-                            .as_ref()
-                            .and_then(|from| from.try_as_full().ok())
-                        else {
-                            return Ok(ElementReducerPoll::Pending(Some(presence.into())));
-                        };
-
-                        // Make sure that the presence is actually sent by our room…
-                        if from.to_bare() != room_bare_jid {
-                            return Ok(ElementReducerPoll::Pending(Some(presence.into())));
-                        }
-
-                        // Is that the self-presence or somebody else's?
-                        let is_self_presence = from.resource() == state.room_jid.resource();
-
-                        // Check if we have an error on our hands (which is addressed at us directly)…
-                        if presence.type_ == presence::Type::Error && is_self_presence {
-                            return if let Some(error_payload) =
-                                presence.payloads.iter().find(|p| p.name() == "error")
-                            {
-                                match StanzaError::try_from(error_payload.clone()) {
-                                    Ok(err) => Err(RequestError::XMPP { err }),
-                                    Err(error) => Err(RequestError::Generic {
-                                        msg: error.to_string(),
-                                    }),
-                                }
-                            } else {
-                                Err(RequestError::Generic {
-                                    msg:
-                                    "Encountered presence of type error with a missing `error` stanza."
-                                        .to_string(),
-                                })
-                            };
-                        }
-
-                        if is_self_presence {
-                            state.self_presence = Some(presence.clone());
-                        } else {
-                            state.presences.push(presence.clone());
-                        }
-
-                        Ok(ElementReducerPoll::Pending(None))
-                    }
-                    XMPPElement::Message(message) => {
-                        // Make sure that the message is actually sent by our room and is
-                        // not a MAM message. Otherwise, we might run into a situation where - when
-                        // a MAM request is performed at the same time as we're connecting to the
-                        // same room - we're consuming all messages from the MAM request.
-                        if message.from.as_ref().map(|jid| jid.to_bare()).as_ref()
-                            != Some(&room_bare_jid)
-                            || message.is_mam_message()
-                        {
-                            return Ok(ElementReducerPoll::Pending(Some(message.into())));
-                        }
-
-                        if let Some(subject) = message.subject() {
-                            // We're done…
-                            state.subject = (!subject.is_empty()).then_some(subject.to_string());
-                            return Ok(ElementReducerPoll::Ready);
-                        }
-
-                        state.message_history.push(message.clone());
-                        Ok(ElementReducerPoll::Pending(None))
-                    }
-                    XMPPElement::IQ(_) | XMPPElement::PubSubMessage(_) => {
-                        Ok(ElementReducerPoll::Pending(Some(element)))
-                    }
-                }
-            },
-            |state| {
-                (
-                    state.self_presence.unwrap_or_else(|| {
-                        panic!(
-                            "Internal error. Missing response in JoinRoomState for room {}.",
-                            state.room_jid
-                        )
-                    }),
-                    state.presences,
-                    state.message_history,
-                    state.subject,
-                )
-            },
-        )
     }
 }

--- a/crates/prose-xmpp/src/mods/muc/send_muc_message_future.rs
+++ b/crates/prose-xmpp/src/mods/muc/send_muc_message_future.rs
@@ -1,0 +1,49 @@
+// prose-core-client/prose-xmpp
+//
+// Copyright: 2024, Marc Bauer <mb@nesium.com>
+// License: Mozilla Public License v2.0 (MPL v2.0)
+
+use jid::BareJid;
+
+use crate::stanza::Message;
+use crate::util::{ElementReducerPoll, RequestFuture, XMPPElement};
+
+pub struct SendMucMessageState {
+    room_jid: BareJid,
+    sent_message_id: String,
+    received_message: Option<Message>,
+}
+
+impl RequestFuture<SendMucMessageState, Message> {
+    pub fn new_send_muc_message(room_jid: BareJid, sent_message_id: String) -> Self {
+        RequestFuture::new(
+            format!("MUC Message {sent_message_id} -> {room_jid}"),
+            SendMucMessageState {
+                room_jid,
+                sent_message_id,
+                received_message: None,
+            },
+            move |state, element| match element {
+                XMPPElement::Presence(_) | XMPPElement::IQ(_) | XMPPElement::PubSubMessage(_) => {
+                    Ok(ElementReducerPoll::Pending(Some(element)))
+                }
+                XMPPElement::Message(message) => {
+                    if message.id.as_ref() != Some(&state.sent_message_id)
+                        || message.from.as_ref().map(|from| from.to_bare()).as_ref()
+                            != Some(&state.room_jid)
+                    {
+                        return Ok(ElementReducerPoll::Pending(Some(message.into())));
+                    }
+
+                    state.received_message = Some(message);
+                    return Ok(ElementReducerPoll::Ready);
+                }
+            },
+            |state| {
+                state
+                    .received_message
+                    .expect("Internal error. Missing received message in SendMucMessageState.")
+            },
+        )
+    }
+}

--- a/examples/prose-core-client-cli/src/type_display.rs
+++ b/examples/prose-core-client-cli/src/type_display.rs
@@ -205,11 +205,7 @@ impl Display for MessageEnvelope {
             f,
             "{} | {:<36} | {:<20} | {} attachments | {} mentions | {}{}",
             self.0.timestamp.format("%Y/%m/%d %H:%M:%S"),
-            self.0
-                .id
-                .as_ref()
-                .map(|id| id.clone().into_inner())
-                .unwrap_or("<no-id>".to_string()),
+            self.0.id,
             self.0.from.id.to_opaque_identifier().truncate_to(20),
             self.0.attachments.len(),
             self.0.mentions.len(),
@@ -231,11 +227,7 @@ impl Display for CompactMessageEnvelope {
             f,
             "{} | {:<36} | {:<20} | {}",
             self.0.timestamp.format("%Y/%m/%d %H:%M:%S"),
-            self.0
-                .id
-                .as_ref()
-                .map(|id| id.clone().into_inner())
-                .unwrap_or("<no-id>".to_string()),
+            self.0.id,
             self.0.from.id.to_opaque_identifier().truncate_to(20),
             self.0.body.html.to_string().truncate_to(40),
         )

--- a/examples/prose-core-client-cli/src/type_selection.rs
+++ b/examples/prose-core-client-cli/src/type_selection.rs
@@ -6,14 +6,14 @@
 use std::iter;
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::{Input, MultiSelect, Select};
 use jid::BareJid;
 
 use prose_core_client::dtos::{
-    DeviceId, Message, MessageRemoteId, MessageServerId, ParticipantInfo, PublicRoomInfo,
-    RoomEnvelope, SidebarItem, UserId,
+    DeviceId, Message, MessageId, MessageServerId, ParticipantInfo, PublicRoomInfo, RoomEnvelope,
+    SidebarItem, UserId,
 };
 use prose_core_client::services::{Generic, Room};
 use prose_core_client::Client;
@@ -120,13 +120,11 @@ pub async fn select_participant<T>(room: &Room<T>) -> Option<ParticipantInfo> {
     select_item_from_list(room.participants(), |p| ParticipantEnvelope(p.clone()))
 }
 
-pub async fn select_message(room: &Room<Generic>) -> Result<Option<MessageRemoteId>> {
+pub async fn select_message(room: &Room<Generic>) -> Result<Option<MessageId>> {
     let messages = load_messages(room, 1).await?;
     let message =
         select_item_from_list(messages, |message| CompactMessageEnvelope(message.clone()));
-    Ok(message
-        .map(|m| m.id.ok_or(anyhow!("Selected message does not have an ID")))
-        .transpose()?)
+    Ok(message.map(|m| m.id))
 }
 
 pub async fn select_public_channel(client: &Client) -> Result<Option<PublicRoomInfo>> {

--- a/tests/prose-core-integration-tests/src/lib.rs
+++ b/tests/prose-core-integration-tests/src/lib.rs
@@ -3,10 +3,16 @@
 // Copyright: 2023, Marc Bauer <mb@nesium.com>
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
+use tracing::Level;
+
 #[cfg(not(target_arch = "wasm32"))]
 #[ctor::ctor]
 fn init() {
-    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        // Set this to Level::DEBUG to log SQL queries…
+        .with_max_level(Level::INFO)
+        .try_init();
 }
 
 #[cfg(test)]

--- a/tests/prose-core-integration-tests/src/tests/client/message_handling.rs
+++ b/tests/prose-core-integration-tests/src/tests/client/message_handling.rs
@@ -1,0 +1,495 @@
+// prose-core-client/prose-core-integration-tests
+//
+// Copyright: 2024, Marc Bauer <mb@nesium.com>
+// License: Mozilla Public License v2.0 (MPL v2.0)
+
+use crate::tests::client::helpers::{StartDMStrategy, TestClient};
+use crate::tests::store;
+use crate::{event, recv, room_event, send};
+use anyhow::Result;
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use itertools::Itertools;
+use minidom::Element;
+use pretty_assertions::assert_eq;
+use prose_core_client::domain::messaging::repos::MessagesRepository;
+use prose_core_client::domain::shared::models::AnonOccupantId;
+use prose_core_client::dtos::{
+    AccountId, MucId, RoomId, SendMessageRequest, SendMessageRequestBody, UserId,
+};
+use prose_core_client::infra::messaging::CachingMessageRepository;
+use prose_core_client::test::MessageBuilder;
+use prose_core_client::{account_id, muc_id, user_id, ClientEvent, ClientRoomEventType};
+use prose_proc_macros::mt_test;
+use prose_xmpp::stanza::Message;
+use prose_xmpp::{bare, TimeProvider};
+use xmpp_parsers::mam::QueryId;
+
+#[mt_test]
+async fn test_receives_message_with_same_id_twice() -> Result<()> {
+    let client = TestClient::new().await;
+    client
+        .expect_login(user_id!("user@prose.org"), "secret")
+        .await?;
+
+    let other_user_id = user_id!("other@prose.org");
+    client.push_ctx([("OTHER_USER_ID", other_user_id.to_string())]);
+
+    let room = client
+        .start_dm(other_user_id.clone())
+        .await?
+        .to_generic_room();
+
+    let message1_id = client.get_next_message_id_with_offset(1);
+    let message2_id = client.get_next_message_id_with_offset(2);
+
+    {
+        recv!(
+            client,
+            r#"
+            <message xmlns="jabber:client" from="{{OTHER_USER_ID}}" id="message-id" to="{{USER_RESOURCE_ID}}" type="chat">
+              <body>Message 1</body>
+            </message>
+            "#
+        );
+
+        event!(client, ClientEvent::SidebarChanged);
+        room_event!(
+            client,
+            room.jid().clone(),
+            ClientRoomEventType::MessagesAppended {
+                message_ids: vec![message1_id.clone()]
+            }
+        );
+    }
+    client.receive_next().await;
+
+    {
+        recv!(
+            client,
+            r#"
+            <message xmlns="jabber:client" from="{{OTHER_USER_ID}}" id="message-id" to="{{USER_RESOURCE_ID}}" type="chat">
+              <body>Message 2</body>
+            </message>
+            "#
+        );
+
+        event!(client, ClientEvent::SidebarChanged);
+        room_event!(
+            client,
+            room.jid().clone(),
+            ClientRoomEventType::MessagesAppended {
+                message_ids: vec![message2_id.clone()]
+            }
+        );
+    }
+    client.receive_next().await;
+
+    let messages = room
+        .load_messages_with_ids(&[message1_id, message2_id])
+        .await?
+        .into_iter()
+        .map(|msg| msg.body.raw)
+        .collect::<Vec<_>>();
+
+    assert_eq!(vec!["Message 1", "Message 2"], messages);
+
+    Ok(())
+}
+
+#[mt_test]
+async fn test_updates_existing_messages_on_catchup() -> Result<()> {
+    let store = store().await.expect("Failed to set up store.");
+    let client = TestClient::builder().set_store(store.clone()).build().await;
+
+    let account = account_id!("user@prose.org");
+    let user_id = user_id!("other@prose.org");
+    let room_id = RoomId::User(user_id.clone());
+
+    let message_repo = CachingMessageRepository::new(store.clone());
+    message_repo
+        .append(
+            &account,
+            &room_id,
+            &[
+                MessageBuilder::new_with_index(1)
+                    .set_from(account.to_user_id())
+                    .set_timestamp(Utc.with_ymd_and_hms(2024, 04, 25, 10, 00, 00).unwrap())
+                    .set_id("custom-msg-id-1")
+                    .set_server_id(None)
+                    .set_remote_id(Some("remote-id-1".into()))
+                    .build_message_like(),
+                MessageBuilder::new_with_index(2)
+                    .set_from(user_id.clone())
+                    .set_timestamp(Utc.with_ymd_and_hms(2024, 04, 25, 10, 00, 10).unwrap())
+                    .set_id("custom-msg-id-2")
+                    .set_server_id(Some("server-id-2".into()))
+                    .set_remote_id(Some("remote-id-2".into()))
+                    .build_message_like(),
+            ],
+        )
+        .await?;
+
+    client.expect_login(account.to_user_id(), "secret").await?;
+
+    let join_dm_strategy = StartDMStrategy::default().with_catch_up_handler({
+        let account = account.clone();
+        move |client, user_id| {
+            client.expect_catchup_with_config(
+                user_id,
+                client.time_provider.now()
+                    - Duration::seconds(client.app_config.max_catchup_duration_secs),
+                vec![
+                    MessageBuilder::new_with_index(1)
+                        .set_from(account.to_user_id())
+                        .set_timestamp(Utc.with_ymd_and_hms(2024, 04, 26, 10, 00, 00).unwrap())
+                        .set_remote_id(Some("remote-id-1".into()))
+                        .set_server_id(Some("server-id-1".into()))
+                        .build_archived_message("", None),
+                    MessageBuilder::new_with_index(2)
+                        .set_from(user_id.clone())
+                        .set_timestamp(Utc.with_ymd_and_hms(2024, 04, 26, 10, 10, 00).unwrap())
+                        .set_remote_id(Some("remote-id-2".into()))
+                        .set_server_id(Some("server-id-2".into()))
+                        .build_archived_message("", None),
+                    MessageBuilder::new_with_index(3)
+                        .set_from(user_id.clone())
+                        .set_timestamp(Utc.with_ymd_and_hms(2024, 04, 26, 10, 20, 00).unwrap())
+                        .set_remote_id(Some("remote-id-3".into()))
+                        .set_server_id(Some("server-id-3".into()))
+                        .build_archived_message("", None),
+                ],
+            )
+        }
+    });
+
+    let new_message_id = client.get_next_message_id();
+
+    client
+        .start_dm_with_strategy(user_id.clone(), join_dm_strategy)
+        .await?;
+
+    let messages = message_repo
+        .get_messages_after(&account, &room_id, DateTime::<Utc>::MIN_UTC)
+        .await?
+        .into_iter()
+        .map(|msg| (msg.id, msg.server_id, msg.timestamp))
+        .sorted_by(|l, r| l.2.cmp(&r.2))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        vec![
+            (
+                "custom-msg-id-1".into(),
+                Some("server-id-1".into()),
+                Utc.with_ymd_and_hms(2024, 04, 26, 10, 00, 00).unwrap()
+            ),
+            (
+                "custom-msg-id-2".into(),
+                Some("server-id-2".into()),
+                Utc.with_ymd_and_hms(2024, 04, 26, 10, 10, 00).unwrap()
+            ),
+            (
+                new_message_id,
+                Some("server-id-3".into()),
+                Utc.with_ymd_and_hms(2024, 04, 26, 10, 20, 00).unwrap()
+            ),
+        ],
+        messages
+    );
+
+    Ok(())
+}
+
+#[mt_test]
+async fn test_updates_existing_messages_when_loading_from_mam() -> Result<()> {
+    let store = store().await.expect("Failed to set up store.");
+    let client = TestClient::builder().set_store(store.clone()).build().await;
+
+    let account = account_id!("user@prose.org");
+    let user_id = user_id!("other@prose.org");
+    let room_id = RoomId::User(user_id.clone());
+
+    client.push_ctx([("OTHER_USER_ID", user_id.to_string())]);
+
+    let message_repo = CachingMessageRepository::new(store.clone());
+    message_repo
+        .append(
+            &account,
+            &room_id,
+            &[
+                // A message by us without a StanzaId
+                MessageBuilder::new_with_index(1)
+                    .set_from(account.to_user_id())
+                    .set_timestamp(Utc.with_ymd_and_hms(2024, 04, 25, 10, 00, 00).unwrap())
+                    .set_id("custom-msg-id-1")
+                    .set_server_id(None)
+                    .set_remote_id(Some("remote-id-1".into()))
+                    .build_message_like(),
+                // A message by them with a StanzaId
+                MessageBuilder::new_with_index(2)
+                    .set_from(user_id.clone())
+                    .set_timestamp(Utc.with_ymd_and_hms(2024, 04, 25, 10, 00, 10).unwrap())
+                    .set_id("custom-msg-id-2")
+                    .set_server_id(Some("server-id-2".into()))
+                    .set_remote_id(Some("remote-id-2".into()))
+                    .build_message_like(),
+            ],
+        )
+        .await?;
+
+    client.expect_login(account.to_user_id(), "secret").await?;
+
+    let room = client.start_dm(user_id.clone()).await?.to_generic_room();
+
+    send!(
+        client,
+        r#"
+        <iq xmlns="jabber:client" id="{{ID:2}}" type="set">
+          <query xmlns="urn:xmpp:mam:2" queryid="{{ID:1}}">
+            <x xmlns="jabber:x:data" type="submit">
+              <field type="hidden" var="FORM_TYPE">
+                <value>urn:xmpp:mam:2</value>
+              </field>
+              <field var="with">
+                <value>{{OTHER_USER_ID}}</value>
+              </field>
+            </x>
+            <set xmlns="http://jabber.org/protocol/rsm">
+              <max>100</max>
+              <before />
+            </set>
+          </query>
+        </iq>
+    "#
+    );
+
+    let query_id = QueryId(client.id_provider.id_with_offset(1));
+
+    let received_messages = vec![
+        // This should update our message
+        MessageBuilder::new_with_index(1)
+            .set_from(account.to_user_id())
+            .set_timestamp(Utc.with_ymd_and_hms(2024, 04, 26, 10, 00, 00).unwrap())
+            .set_remote_id(Some("remote-id-1".into()))
+            .set_server_id(Some("server-id-1".into()))
+            .build_archived_message("", None),
+        // This should update their message
+        MessageBuilder::new_with_index(2)
+            .set_from(user_id.clone())
+            .set_timestamp(Utc.with_ymd_and_hms(2024, 04, 26, 10, 10, 00).unwrap())
+            .set_remote_id(Some("remote-id-2".into()))
+            .set_server_id(Some("server-id-2".into()))
+            .build_archived_message("", None),
+        // This should create a new message
+        MessageBuilder::new_with_index(3)
+            .set_from(user_id.clone())
+            .set_timestamp(Utc.with_ymd_and_hms(2024, 04, 26, 10, 20, 00).unwrap())
+            .set_remote_id(Some("remote-id-3".into()))
+            .set_server_id(Some("server-id-3".into()))
+            .build_archived_message("", None),
+    ];
+
+    for mut archived_message in received_messages.into_iter() {
+        archived_message.query_id = Some(query_id.clone());
+
+        let message = Message::new().set_archived_message(archived_message);
+        client.receive_element(Element::from(message), file!(), line!());
+    }
+
+    recv!(
+        client,
+        r#"
+            <iq xmlns="jabber:client" id="{{ID}}" to="{{USER_RESOURCE_ID}}" type="result">
+                <fin xmlns="urn:xmpp:mam:2" complete="true">
+                    <set xmlns="http://jabber.org/protocol/rsm" />
+                </fin>
+            </iq>
+            "#
+    );
+
+    let new_message_id = client.get_next_message_id();
+
+    _ = room.load_latest_messages().await?;
+
+    let messages = message_repo
+        .get_messages_after(&account, &room_id, DateTime::<Utc>::MIN_UTC)
+        .await?
+        .into_iter()
+        .map(|msg| (msg.id, msg.server_id, msg.timestamp))
+        .sorted_by(|l, r| l.2.cmp(&r.2))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        vec![
+            (
+                "custom-msg-id-1".into(),
+                Some("server-id-1".into()),
+                Utc.with_ymd_and_hms(2024, 04, 26, 10, 00, 00).unwrap()
+            ),
+            (
+                "custom-msg-id-2".into(),
+                Some("server-id-2".into()),
+                Utc.with_ymd_and_hms(2024, 04, 26, 10, 10, 00).unwrap()
+            ),
+            (
+                new_message_id,
+                Some("server-id-3".into()),
+                Utc.with_ymd_and_hms(2024, 04, 26, 10, 20, 00).unwrap()
+            ),
+        ],
+        messages
+    );
+
+    Ok(())
+}
+
+#[mt_test]
+async fn test_sends_and_updates_message_to_muc_room() -> Result<()> {
+    let store = store().await.expect("Failed to set up store.");
+    let client = TestClient::builder().set_store(store.clone()).build().await;
+
+    client
+        .expect_login(user_id!("user@prose.org"), "secret")
+        .await?;
+
+    let room_id = muc_id!("room@conference.prose.org");
+    let occupant_id = client.build_occupant_id(&room_id);
+    let anon_occupant_id = AnonOccupantId::from("anon-occupant-id");
+
+    client
+        .join_room(room_id.clone(), anon_occupant_id.clone())
+        .await?;
+
+    client.push_ctx([
+        ("OCCUPANT_ID", occupant_id.to_string()),
+        ("ROOM_ID", room_id.to_string()),
+        ("ANON_OCCUPANT_ID", anon_occupant_id.to_string()),
+    ]);
+
+    let message_id = client.get_next_message_id();
+
+    send!(
+        client,
+        r#"
+        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{MSG_ID}}" to="{{ROOM_ID}}" type="groupchat">
+          <body>Hello</body>
+          <content xmlns="urn:xmpp:content" type="text/markdown">Hello</content>
+          <active xmlns="http://jabber.org/protocol/chatstates" />
+          <markable xmlns="urn:xmpp:chat-markers:0" />
+          <store xmlns="urn:xmpp:hints" />
+        </message>
+        "#
+    );
+
+    room_event!(
+        client,
+        room_id.clone(),
+        ClientRoomEventType::MessagesAppended {
+            message_ids: vec![message_id.clone().into()]
+        }
+    );
+
+    let room = client.get_room(room_id.clone()).await.to_generic_room();
+    room.send_message(SendMessageRequest {
+        body: Some(SendMessageRequestBody {
+            text: "Hello".into(),
+        }),
+        attachments: vec![],
+    })
+    .await?;
+
+    recv!(
+        client,
+        r#"
+        <message xmlns="jabber:client" from="{{OCCUPANT_ID}}" id="{{LAST_MSG_ID}}" to="{{USER_RESOURCE_ID}}" type="groupchat" xml:lang="en">
+          <body>Hello</body>
+          <active xmlns="http://jabber.org/protocol/chatstates" />
+          <markable xmlns="urn:xmpp:chat-markers:0" />
+          <store xmlns="urn:xmpp:hints" />
+          <occupant-id xmlns="urn:xmpp:occupant-id:0" id="{{ANON_OCCUPANT_ID}}" />
+          <stanza-id xmlns="urn:xmpp:sid:0" by="{{ROOM_ID}}" id="opZdWmO7r50ee_aGKnWvBMbK" />
+        </message>
+        "#
+    );
+
+    client.receive_next().await;
+
+    let messages = CachingMessageRepository::new(store)
+        .get(
+            &bare!("user@prose.org").into(),
+            &room_id.clone().into(),
+            &message_id,
+        )
+        .await?;
+
+    assert_eq!(1, messages.len());
+    assert_eq!(
+        Some("opZdWmO7r50ee_aGKnWvBMbK".into()),
+        messages[0].server_id,
+    );
+
+    client.push_ctx([("INITIAL_MESSAGE_ID", message_id.to_string())]);
+
+    send!(
+        client,
+        r#"
+        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{MSG_ID}}" to="{{ROOM_ID}}" type="groupchat">
+          <body>Hello World</body>
+          <content xmlns="urn:xmpp:content" type="text/markdown">Hello World</content>
+          <replace xmlns="urn:xmpp:message-correct:0" id="{{INITIAL_MESSAGE_ID}}" />
+          <store xmlns="urn:xmpp:hints" />
+        </message>
+        "#
+    );
+
+    room_event!(
+        client,
+        room_id.clone(),
+        ClientRoomEventType::MessagesUpdated {
+            message_ids: vec![message_id.clone().into()]
+        }
+    );
+
+    room.update_message(
+        message_id.clone().into(),
+        SendMessageRequest {
+            body: Some(SendMessageRequestBody {
+                text: "Hello World".into(),
+            }),
+            attachments: vec![],
+        },
+    )
+    .await?;
+
+    let messages = room
+        .load_messages_with_ids(&[message_id.clone().into()])
+        .await?;
+    assert_eq!(1, messages.len());
+    assert_eq!("<p>Hello World</p>", messages[0].body.html.as_ref());
+
+    recv!(
+        client,
+        r#"
+        <message xmlns="jabber:client" from="{{OCCUPANT_ID}}" id="{{LAST_MSG_ID}}" to="{{USER_RESOURCE_ID}}" type="groupchat" xml:lang="en">
+          <body>Hello World</body>
+          <replace xmlns="urn:xmpp:message-correct:0" id="{{INITIAL_MESSAGE_ID}}" />
+          <store xmlns="urn:xmpp:hints" />
+          <occupant-id xmlns="urn:xmpp:occupant-id:0" id="{{ANON_OCCUPANT_ID}}" />
+          <stanza-id xmlns="urn:xmpp:sid:0" by="{{ROOM_ID}}" id="907z40xwIIuX4b1YH5jRv1ko" />
+        </message>
+        "#
+    );
+
+    client.receive_next().await;
+
+    let messages = room
+        .load_messages_with_ids(&[message_id.clone().into()])
+        .await?;
+    assert_eq!(1, messages.len());
+    assert_eq!("<p>Hello World</p>", messages[0].body.html.as_ref());
+
+    client.pop_ctx();
+    client.pop_ctx();
+
+    Ok(())
+}

--- a/tests/prose-core-integration-tests/src/tests/client/message_styling.rs
+++ b/tests/prose-core-integration-tests/src/tests/client/message_styling.rs
@@ -28,7 +28,7 @@ async fn test_send_markdown_message() -> Result<()> {
     send!(
         client,
         r#"
-        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{ID}}" to="them@prose.org" type="chat">
+        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{MSG_ID}}" to="them@prose.org" type="chat">
           <body>Some *bold*, _italic_, ~strikethrough~ and *_bold italic_* text.</body>
           <content xmlns="urn:xmpp:content" type="text/markdown">Some **bold**, _italic_, ~~strikethrough~~ and **_bold italic_** text.</content>
           <active xmlns="http://jabber.org/protocol/chatstates" />
@@ -42,7 +42,7 @@ async fn test_send_markdown_message() -> Result<()> {
         client,
         room.jid().clone(),
         ClientRoomEventType::MessagesAppended {
-            message_ids: vec![client.get_last_id().into()]
+            message_ids: vec![client.get_last_message_id()]
         }
     );
 
@@ -82,20 +82,20 @@ async fn test_receive_markdown_message() -> Result<()> {
         "#
     );
 
+    let message_id = client.get_next_message_id();
+
     event!(client, ClientEvent::SidebarChanged);
     room_event!(
         client,
         room.jid().clone(),
         ClientRoomEventType::MessagesAppended {
-            message_ids: vec!["my-message-id".into()]
+            message_ids: vec![message_id.clone()]
         }
     );
 
     client.receive_next().await;
 
-    let messages = room
-        .load_messages_with_ids(&["my-message-id".into()])
-        .await?;
+    let messages = room.load_messages_with_ids(&[message_id]).await?;
 
     let message = messages.first().unwrap();
 
@@ -137,20 +137,20 @@ And another newline</body>
         "#
     );
 
+    let message_id = client.get_next_message_id();
+
     event!(client, ClientEvent::SidebarChanged);
     room_event!(
         client,
         room.jid().clone(),
         ClientRoomEventType::MessagesAppended {
-            message_ids: vec!["my-message-id".into()]
+            message_ids: vec![message_id.clone()]
         }
     );
 
     client.receive_next().await;
 
-    let messages = room
-        .load_messages_with_ids(&["my-message-id".into()])
-        .await?;
+    let messages = room.load_messages_with_ids(&[message_id]).await?;
 
     let message = messages.first().unwrap();
 

--- a/tests/prose-core-integration-tests/src/tests/client/mod.rs
+++ b/tests/prose-core-integration-tests/src/tests/client/mod.rs
@@ -6,6 +6,7 @@
 mod catchup_unread;
 mod contact_list;
 mod helpers;
+mod message_handling;
 mod message_styling;
 mod muc;
 mod muc_omemo;

--- a/tests/prose-core-integration-tests/src/tests/client/omemo.rs
+++ b/tests/prose-core-integration-tests/src/tests/client/omemo.rs
@@ -143,7 +143,7 @@ async fn test_does_not_start_session_when_sending_message_in_non_encrypted_room(
     send!(
         client,
         r#"
-        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{ID}}" to="them@prose.org" type="chat">
+        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{MSG_ID}}" to="them@prose.org" type="chat">
           <body>Hello World</body>
           <content xmlns="urn:xmpp:content" type="text/markdown">Hello World</content>
           <active xmlns="http://jabber.org/protocol/chatstates" />
@@ -157,7 +157,7 @@ async fn test_does_not_start_session_when_sending_message_in_non_encrypted_room(
         client,
         room.jid().clone(),
         ClientRoomEventType::MessagesAppended {
-            message_ids: vec![client.get_last_id().into()]
+            message_ids: vec![client.get_last_message_id()]
         }
     );
 
@@ -256,7 +256,7 @@ async fn test_start_session_when_sending_message_in_encrypted_room() -> Result<(
     send!(
         client,
         r#"
-        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{ID}}" to="them@prose.org" type="chat">
+        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{MSG_ID}}" to="them@prose.org" type="chat">
           <body>[This message is OMEMO encrypted]</body>
           <encrypted xmlns="eu.siacs.conversations.axolotl">
             <header sid="{{USER_DEVICE_ID}}">
@@ -279,7 +279,7 @@ async fn test_start_session_when_sending_message_in_encrypted_room() -> Result<(
         client,
         room.jid().clone(),
         ClientRoomEventType::MessagesAppended {
-            message_ids: vec![client.get_last_id().into()]
+            message_ids: vec![client.get_last_message_id()]
         }
     );
 
@@ -296,7 +296,7 @@ async fn test_start_session_when_sending_message_in_encrypted_room() -> Result<(
     send!(
         client,
         r#"
-        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{ID}}" to="them@prose.org" type="chat">
+        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{MSG_ID}}" to="them@prose.org" type="chat">
           <body>[This message is OMEMO encrypted]</body>
           <encrypted xmlns="eu.siacs.conversations.axolotl">
             <header sid="{{USER_DEVICE_ID}}">
@@ -319,7 +319,7 @@ async fn test_start_session_when_sending_message_in_encrypted_room() -> Result<(
         client,
         room.jid().clone(),
         ClientRoomEventType::MessagesAppended {
-            message_ids: vec![client.get_last_id().into()]
+            message_ids: vec![client.get_last_message_id()]
         }
     );
 
@@ -363,7 +363,7 @@ async fn test_starts_session_for_new_devices_when_sending() -> Result<()> {
     send!(
         client,
         r#"
-        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{ID}}" to="them@prose.org" type="chat">
+        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{MSG_ID}}" to="them@prose.org" type="chat">
           <body>[This message is OMEMO encrypted]</body>
           <encrypted xmlns="eu.siacs.conversations.axolotl">
             <header sid="{{USER_DEVICE_ID}}">
@@ -384,7 +384,7 @@ async fn test_starts_session_for_new_devices_when_sending() -> Result<()> {
         client,
         room.jid().clone(),
         ClientRoomEventType::MessagesAppended {
-            message_ids: vec![client.get_last_id().into()]
+            message_ids: vec![client.get_last_message_id()]
         }
     );
 
@@ -425,7 +425,7 @@ async fn test_starts_session_for_new_devices_when_sending() -> Result<()> {
     send!(
         client,
         r#"
-        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{ID}}" to="them@prose.org" type="chat">
+        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{MSG_ID}}" to="them@prose.org" type="chat">
           <body>[This message is OMEMO encrypted]</body>
           <encrypted xmlns="eu.siacs.conversations.axolotl">
             <header sid="{{USER_DEVICE_ID}}">
@@ -447,7 +447,7 @@ async fn test_starts_session_for_new_devices_when_sending() -> Result<()> {
         client,
         room.jid().clone(),
         ClientRoomEventType::MessagesAppended {
-            message_ids: vec![client.get_last_id().into()]
+            message_ids: vec![client.get_last_message_id()]
         }
     );
 
@@ -496,7 +496,7 @@ async fn test_marks_disappeared_devices_as_inactive_and_reappeared_as_active() -
     send!(
         client,
         r#"
-        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{ID}}" to="them@prose.org" type="chat">
+        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{MSG_ID}}" to="them@prose.org" type="chat">
           <body>[This message is OMEMO encrypted]</body>
           <encrypted xmlns="eu.siacs.conversations.axolotl">
             <header sid="{{USER_DEVICE_ID}}">
@@ -518,7 +518,7 @@ async fn test_marks_disappeared_devices_as_inactive_and_reappeared_as_active() -
         client,
         room.jid().clone(),
         ClientRoomEventType::MessagesAppended {
-            message_ids: vec![client.get_last_id().into()]
+            message_ids: vec![client.get_last_message_id()]
         }
     );
 
@@ -574,7 +574,7 @@ async fn test_marks_disappeared_devices_as_inactive_and_reappeared_as_active() -
     send!(
         client,
         r#"
-        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{ID}}" to="them@prose.org" type="chat">
+        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{MSG_ID}}" to="them@prose.org" type="chat">
           <body>[This message is OMEMO encrypted]</body>
           <encrypted xmlns="eu.siacs.conversations.axolotl">
             <header sid="{{USER_DEVICE_ID}}">
@@ -596,7 +596,7 @@ async fn test_marks_disappeared_devices_as_inactive_and_reappeared_as_active() -
         client,
         room.jid().clone(),
         ClientRoomEventType::MessagesAppended {
-            message_ids: vec![client.get_last_id().into()]
+            message_ids: vec![client.get_last_message_id()]
         }
     );
 
@@ -647,7 +647,7 @@ async fn test_marks_disappeared_devices_as_inactive_and_reappeared_as_active() -
     send!(
         client,
         r#"
-        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{ID}}" to="them@prose.org" type="chat">
+        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{MSG_ID}}" to="them@prose.org" type="chat">
           <body>[This message is OMEMO encrypted]</body>
           <encrypted xmlns="eu.siacs.conversations.axolotl">
             <header sid="{{USER_DEVICE_ID}}">
@@ -670,7 +670,7 @@ async fn test_marks_disappeared_devices_as_inactive_and_reappeared_as_active() -
         client,
         room.jid().clone(),
         ClientRoomEventType::MessagesAppended {
-            message_ids: vec![client.get_last_id().into()]
+            message_ids: vec![client.get_last_message_id()]
         }
     );
 
@@ -738,7 +738,7 @@ async fn test_marks_own_disappeared_devices_as_inactive() -> Result<()> {
     send!(
         client,
         r#"
-        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{ID}}" to="them@prose.org" type="chat">
+        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{MSG_ID}}" to="them@prose.org" type="chat">
           <body>[This message is OMEMO encrypted]</body>
           <encrypted xmlns="eu.siacs.conversations.axolotl">
             <header sid="{{USER_DEVICE_ID}}">
@@ -761,7 +761,7 @@ async fn test_marks_own_disappeared_devices_as_inactive() -> Result<()> {
         client,
         room.jid().clone(),
         ClientRoomEventType::MessagesAppended {
-            message_ids: vec![client.get_last_id().into()]
+            message_ids: vec![client.get_last_message_id()]
         }
     );
 
@@ -796,7 +796,7 @@ async fn test_marks_own_disappeared_devices_as_inactive() -> Result<()> {
     send!(
         client,
         r#"
-        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{ID}}" to="them@prose.org" type="chat">
+        <message xmlns="jabber:client" from="{{USER_RESOURCE_ID}}" id="{{MSG_ID}}" to="them@prose.org" type="chat">
           <body>[This message is OMEMO encrypted]</body>
           <encrypted xmlns="eu.siacs.conversations.axolotl">
             <header sid="{{USER_DEVICE_ID}}">
@@ -818,7 +818,7 @@ async fn test_marks_own_disappeared_devices_as_inactive() -> Result<()> {
         client,
         room.jid().clone(),
         ClientRoomEventType::MessagesAppended {
-            message_ids: vec![client.get_last_id().into()]
+            message_ids: vec![client.get_last_message_id()]
         }
     );
 
@@ -905,20 +905,20 @@ async fn test_starts_session_and_decrypts_received_messages() -> Result<()> {
         "#
     );
 
+    let message_id = client.get_next_message_id();
+
     event!(client, ClientEvent::SidebarChanged);
     room_event!(
         client,
         room.jid().clone(),
         ClientRoomEventType::MessagesAppended {
-            message_ids: vec!["my-message-id".into()]
+            message_ids: vec![message_id.clone()]
         }
     );
 
     client.receive_next().await;
 
-    let messages = room
-        .load_messages_with_ids(&["my-message-id".into()])
-        .await?;
+    let messages = room.load_messages_with_ids(&[message_id]).await?;
     assert_eq!(messages.len(), 1);
     assert_eq!(
         messages.first().unwrap().body.html.as_ref(),
@@ -957,7 +957,7 @@ async fn test_starts_session_and_decrypts_received_messages() -> Result<()> {
     recv!(
         client,
         r#"
-        <message xmlns="jabber:client" from="them@prose.org" id="other-message-id" to="{{USER_ID}}" type="chat">
+        <message xmlns="jabber:client" from="them@prose.org" id="{{MSG_ID}}" to="{{USER_ID}}" type="chat">
           <body>[This message is OMEMO encrypted]</body>
           {{ENCRYPTED_PAYLOAD}}
           <encryption xmlns="urn:xmpp:eme:0" name="OMEMO" namespace="eu.siacs.conversations.axolotl" />
@@ -984,12 +984,14 @@ async fn test_starts_session_and_decrypts_received_messages() -> Result<()> {
         "#
     );
 
+    let message_id = client.get_next_message_id();
+
     event!(client, ClientEvent::SidebarChanged);
     room_event!(
         client,
         room.jid().clone(),
         ClientRoomEventType::MessagesAppended {
-            message_ids: vec!["other-message-id".into()]
+            message_ids: vec![message_id.clone()]
         }
     );
 
@@ -997,9 +999,7 @@ async fn test_starts_session_and_decrypts_received_messages() -> Result<()> {
 
     // Second message should not contain a pre-key, thus the bundle shouldn't be published again.
 
-    let messages = room
-        .load_messages_with_ids(&["other-message-id".into()])
-        .await?;
+    let messages = room.load_messages_with_ids(&[message_id]).await?;
     assert_eq!(messages.len(), 1);
     assert_eq!(
         messages.first().unwrap().body.html.as_ref(),

--- a/tests/prose-core-integration-tests/src/tests/client/reactions.rs
+++ b/tests/prose-core-integration-tests/src/tests/client/reactions.rs
@@ -24,6 +24,7 @@ async fn test_reactions() -> Result<()> {
         .await?;
 
     let room_id = muc_id!("room@conf.prose.org");
+    let message_id = client.get_next_message_id();
 
     let messages = vec![
         Element::from_pretty_printed_xml(r#"
@@ -90,9 +91,9 @@ async fn test_reactions() -> Result<()> {
         .await?;
 
     let room = client.get_room(room_id).await.to_generic_room();
-    let messages = room.load_messages_with_ids(&["id-1".into()]).await?;
+    let messages = room.load_messages_with_ids(&[message_id]).await?;
 
-    assert_eq!(messages.len(), 1);
+    assert_eq!(1, messages.len());
 
     let message = messages.get(0).unwrap();
 


### PR DESCRIPTION
Todo:
- [ ] Recognize duplicate messages and update them if needed instead of inserting them as a new message (1)
- [ ] Introduce `MessagingDomainService` and move message sending/receiving code there as well as duplicate detection
- [ ] Fix tests

(1) See:
- Conversations [MessageParser.java#L722](https://codeberg.org/iNPUTmice/Conversations/src/commit/79fbc3bdd25eee7f7ccefe83e78f2d37002b639b/src/main/java/eu/siacs/conversations/parser/MessageParser.java#L722)
- Conversations [Message.java#L550](https://codeberg.org/iNPUTmice/Conversations/src/commit/79fbc3bdd25eee7f7ccefe83e78f2d37002b639b/src/main/java/eu/siacs/conversations/entities/Message.java#L550)
